### PR TITLE
Added `replaceWith` method

### DIFF
--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -77,6 +77,26 @@ Router.prototype = {
   },
 
   /**
+    Hook point for updating the URL.
+
+    @param {String} url a URL to update to
+  */
+  updateURL: function() {
+    throw "updateURL is not implemented";
+  },
+
+  /**
+    Hook point for replacing the current URL, i.e. with replaceState
+
+    By default this behaves the same as `updateURL`
+
+    @param {String} url a URL to update to
+  */
+  replaceURL: function(url) {
+    this.updateURL(url);
+  },
+
+  /**
     Transition into the specified named route.
 
     If necessary, trigger the exit callback on any handlers
@@ -85,18 +105,21 @@ Router.prototype = {
     @param {String} name the name of the route
   */
   transitionTo: function(name) {
-    var output = this._paramsForHandler(name, [].slice.call(arguments, 1), function(handler) {
-      if (handler.hasOwnProperty('context')) { return handler.context; }
-      if (handler.deserialize) { return handler.deserialize({}); }
-      return null;
-    });
+    var args = Array.prototype.slice.call(arguments, 1);
+    doTransition(this, name, this.updateURL, args);
+  },
 
-    var params = output.params, toSetup = output.toSetup;
+  /**
+    Identical to `transitionTo` except that the current URL will be replaced
+    if possible.
 
-    var url = this.recognizer.generate(name, params);
-    this.updateURL(url);
+    This method is intended primarily for use with `replaceState`.
 
-    setupContexts(this, toSetup);
+    @param {String} name the name of the route
+  */
+  replaceWith: function(name) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    doTransition(this, name, this.replaceURL, args);
   },
 
   /**
@@ -266,6 +289,24 @@ function failure(router, error) {
   loaded(router);
   var handler = router.getHandler('failure');
   if (handler && handler.setup) { handler.setup(error); }
+}
+
+/**
+  @private
+*/
+function doTransition(router, name, method, args) {
+  var output = router._paramsForHandler(name, args, function(handler) {
+    if (handler.hasOwnProperty('context')) { return handler.context; }
+    if (handler.deserialize) { return handler.deserialize({}); }
+    return null;
+  });
+
+  var params = output.params, toSetup = output.toSetup;
+
+  var url = router.recognizer.generate(name, params);
+  method.call(router, url);
+
+  setupContexts(router, toSetup);
 }
 
 /**

--- a/dist/router.js
+++ b/dist/router.js
@@ -77,6 +77,26 @@
     },
 
     /**
+      Hook point for updating the URL.
+
+      @param {String} url a URL to update to
+    */
+    updateURL: function() {
+      throw "updateURL is not implemented";
+    },
+
+    /**
+      Hook point for replacing the current URL, i.e. with replaceState
+
+      By default this behaves the same as `updateURL`
+
+      @param {String} url a URL to update to
+    */
+    replaceURL: function(url) {
+      this.updateURL(url);
+    },
+
+    /**
       Transition into the specified named route.
 
       If necessary, trigger the exit callback on any handlers
@@ -85,18 +105,21 @@
       @param {String} name the name of the route
     */
     transitionTo: function(name) {
-      var output = this._paramsForHandler(name, [].slice.call(arguments, 1), function(handler) {
-        if (handler.hasOwnProperty('context')) { return handler.context; }
-        if (handler.deserialize) { return handler.deserialize({}); }
-        return null;
-      });
+      var args = Array.prototype.slice.call(arguments, 1);
+      doTransition(this, name, this.updateURL, args);
+    },
 
-      var params = output.params, toSetup = output.toSetup;
+    /**
+      Identical to `transitionTo` except that the current URL will be replaced
+      if possible.
 
-      var url = this.recognizer.generate(name, params);
-      this.updateURL(url);
+      This method is intended primarily for use with `replaceState`.
 
-      setupContexts(this, toSetup);
+      @param {String} name the name of the route
+    */
+    replaceWith: function(name) {
+      var args = Array.prototype.slice.call(arguments, 1);
+      doTransition(this, name, this.replaceURL, args);
     },
 
     /**
@@ -266,6 +289,24 @@
     loaded(router);
     var handler = router.getHandler('failure');
     if (handler && handler.setup) { handler.setup(error); }
+  }
+
+  /**
+    @private
+  */
+  function doTransition(router, name, method, args) {
+    var output = router._paramsForHandler(name, args, function(handler) {
+      if (handler.hasOwnProperty('context')) { return handler.context; }
+      if (handler.deserialize) { return handler.deserialize({}); }
+      return null;
+    });
+
+    var params = output.params, toSetup = output.toSetup;
+
+    var url = router.recognizer.generate(name, params);
+    method.call(router, url);
+
+    setupContexts(router, toSetup);
   }
 
   /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -77,6 +77,26 @@ Router.prototype = {
   },
 
   /**
+    Hook point for updating the URL.
+
+    @param {String} url a URL to update to
+  */
+  updateURL: function() {
+    throw "updateURL is not implemented";
+  },
+
+  /**
+    Hook point for replacing the current URL, i.e. with replaceState
+
+    By default this behaves the same as `updateURL`
+
+    @param {String} url a URL to update to
+  */
+  replaceURL: function(url) {
+    this.updateURL(url);
+  },
+
+  /**
     Transition into the specified named route.
 
     If necessary, trigger the exit callback on any handlers
@@ -85,18 +105,21 @@ Router.prototype = {
     @param {String} name the name of the route
   */
   transitionTo: function(name) {
-    var output = this._paramsForHandler(name, [].slice.call(arguments, 1), function(handler) {
-      if (handler.hasOwnProperty('context')) { return handler.context; }
-      if (handler.deserialize) { return handler.deserialize({}); }
-      return null;
-    });
+    var args = Array.prototype.slice.call(arguments, 1);
+    doTransition(this, name, this.updateURL, args);
+  },
 
-    var params = output.params, toSetup = output.toSetup;
+  /**
+    Identical to `transitionTo` except that the current URL will be replaced
+    if possible.
 
-    var url = this.recognizer.generate(name, params);
-    this.updateURL(url);
+    This method is intended primarily for use with `replaceState`.
 
-    setupContexts(this, toSetup);
+    @param {String} name the name of the route
+  */
+  replaceWith: function(name) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    doTransition(this, name, this.replaceURL, args);
   },
 
   /**
@@ -266,6 +289,24 @@ function failure(router, error) {
   loaded(router);
   var handler = router.getHandler('failure');
   if (handler && handler.setup) { handler.setup(error); }
+}
+
+/**
+  @private
+*/
+function doTransition(router, name, method, args) {
+  var output = router._paramsForHandler(name, args, function(handler) {
+    if (handler.hasOwnProperty('context')) { return handler.context; }
+    if (handler.deserialize) { return handler.deserialize({}); }
+    return null;
+  });
+
+  var params = output.params, toSetup = output.toSetup;
+
+  var url = router.recognizer.generate(name, params);
+  method.call(router, url);
+
+  setupContexts(router, toSetup);
 }
 
 /**

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -25,7 +25,9 @@ module("The router", {
 
     router.getHandler = function(name) {
       return handlers[name];
-    }
+    };
+
+    router.updateURL = function() { };
   }
 });
 
@@ -389,6 +391,31 @@ test("it can handle direct transitions to named routes", function() {
   counter++;
 
   router.transitionTo("showAllPosts");
+});
+
+test("replaceWith calls replaceURL", function() {
+  var updateCount = 0,
+      replaceCount = 0;
+
+  router.updateURL = function() {
+    updateCount++;
+  }
+
+  router.replaceURL = function() {
+    replaceCount++;
+  }
+
+  handlers = {
+    postIndex: { },
+    showAllPosts: { }
+  };
+
+  router.handleURL('/posts');
+
+  router.replaceWith('showAllPosts');
+
+  equal(updateCount, 0, "should not call updateURL");
+  equal(replaceCount, 1, "should call replaceURL once");
 });
 
 asyncTest("if deserialize returns a promise, it enters a loading state", function() {


### PR DESCRIPTION
Identical to `transitionTo` but it calls `replaceURL` instead of
`updateURL`. Useful for transitioning when the new URL should replace the
existing one. This will primarily be used with `replaceState`.
