### PR TITLE
Refactor away confusing UnresolvedHandlerInfo

### DIFF
--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -10,16 +10,10 @@ var RouteRecognizer = require("route-recognizer");
   * `{String} handler`: A handler name
   * `{Object} params`: A hash of recognized parameters
 
-  ## `UnresolvedHandlerInfo`
-
-  * `{Boolean} isDynamic`: whether a handler has any dynamic segments
-  * `{String} name`: the name of a handler
-  * `{Object} context`: the active context for the handler
-
   ## `HandlerInfo`
 
   * `{Boolean} isDynamic`: whether a handler has any dynamic segments
-  * `{String} name`: the original unresolved handler name
+  * `{String} name`: the name of a handler
   * `{Object} handler`: a handler object
   * `{Object} context`: the active context for the handler
 */
@@ -66,8 +60,7 @@ Router.prototype = {
     @return {Array} an Array of `[handler, parameter]` tuples
   */
   handleURL: function(url) {
-    var results = this.recognizer.recognize(url),
-        objects = [];
+    var results = this.recognizer.recognize(url);
 
     if (!results) {
       throw new Error("No route matched the URL '" + url + "'");
@@ -223,8 +216,8 @@ Router.prototype = {
 
       toSetup.push({
         isDynamic: !!handlerObj.names.length,
-        handler: handlerObj.handler,
-        name: handlerObj.name,
+        name: handlerObj.handler,
+        handler: handler,
         context: object
       });
     }
@@ -392,7 +385,8 @@ function collectObjects(router, results, index, objects) {
 
     var updatedObjects = objects.concat([{
       context: value,
-      handler: result.handler,
+      name: result.handler,
+      handler: router.getHandler(result.handler),
       isDynamic: result.isDynamic
     }]);
     collectObjects(router, results, index + 1, updatedObjects);
@@ -402,8 +396,9 @@ function collectObjects(router, results, index, objects) {
 /**
   @private
 
-  Takes an Array of `UnresolvedHandlerInfo`s, resolves the handler names
-  into handlers, and then figures out what to do with each of the handlers.
+  Takes an Array of `HandlerInfo`s, figures out which ones are
+  exiting, entering, or changing contexts, and calls the
+  proper handler hooks.
 
   For example, consider the following tree of handlers. Each handler is
   followed by the URL segment it handles.
@@ -437,11 +432,9 @@ function collectObjects(router, results, index, objects) {
      4. Triggers the `setup` callback on `about`
 
   @param {Router} router
-  @param {Array[UnresolvedHandlerInfo]} handlerInfos
+  @param {Array[HandlerInfo]} handlerInfos
 */
 function setupContexts(router, handlerInfos) {
-  resolveHandlers(router, handlerInfos);
-
   var partition =
     partitionHandlers(router.currentHandlerInfos || [], handlerInfos);
 
@@ -490,28 +483,6 @@ function eachHandler(handlerInfos, callback) {
         context = handlerInfo.context;
 
     callback(handler, context);
-  }
-}
-
-/**
-  @private
-
-  Updates the `handler` field in each element in an Array of
-  `UnresolvedHandlerInfo`s from a handler name to a resolved handler.
-
-  When done, the Array will contain `HandlerInfo` structures.
-
-  @param {Router} router
-  @param {Array[UnresolvedHandlerInfo]} handlerInfos
-*/
-function resolveHandlers(router, handlerInfos) {
-  var handlerInfo;
-
-  for (var i=0, l=handlerInfos.length; i<l; i++) {
-    handlerInfo = handlerInfos[i];
-
-    handlerInfo.name = handlerInfo.handler;
-    handlerInfo.handler = router.getHandler(handlerInfo.handler);
   }
 }
 

--- a/dist/router.js
+++ b/dist/router.js
@@ -10,16 +10,10 @@
     * `{String} handler`: A handler name
     * `{Object} params`: A hash of recognized parameters
 
-    ## `UnresolvedHandlerInfo`
-
-    * `{Boolean} isDynamic`: whether a handler has any dynamic segments
-    * `{String} name`: the name of a handler
-    * `{Object} context`: the active context for the handler
-
     ## `HandlerInfo`
 
     * `{Boolean} isDynamic`: whether a handler has any dynamic segments
-    * `{String} name`: the original unresolved handler name
+    * `{String} name`: the name of a handler
     * `{Object} handler`: a handler object
     * `{Object} context`: the active context for the handler
   */
@@ -66,8 +60,7 @@
       @return {Array} an Array of `[handler, parameter]` tuples
     */
     handleURL: function(url) {
-      var results = this.recognizer.recognize(url),
-          objects = [];
+      var results = this.recognizer.recognize(url);
 
       if (!results) {
         throw new Error("No route matched the URL '" + url + "'");
@@ -223,8 +216,8 @@
 
         toSetup.push({
           isDynamic: !!handlerObj.names.length,
-          handler: handlerObj.handler,
-          name: handlerObj.name,
+          name: handlerObj.handler,
+          handler: handler,
           context: object
         });
       }
@@ -392,7 +385,8 @@
 
       var updatedObjects = objects.concat([{
         context: value,
-        handler: result.handler,
+        name: result.handler,
+        handler: router.getHandler(result.handler),
         isDynamic: result.isDynamic
       }]);
       collectObjects(router, results, index + 1, updatedObjects);
@@ -402,8 +396,9 @@
   /**
     @private
 
-    Takes an Array of `UnresolvedHandlerInfo`s, resolves the handler names
-    into handlers, and then figures out what to do with each of the handlers.
+    Takes an Array of `HandlerInfo`s, figures out which ones are
+    exiting, entering, or changing contexts, and calls the
+    proper handler hooks.
 
     For example, consider the following tree of handlers. Each handler is
     followed by the URL segment it handles.
@@ -437,11 +432,9 @@
        4. Triggers the `setup` callback on `about`
 
     @param {Router} router
-    @param {Array[UnresolvedHandlerInfo]} handlerInfos
+    @param {Array[HandlerInfo]} handlerInfos
   */
   function setupContexts(router, handlerInfos) {
-    resolveHandlers(router, handlerInfos);
-
     var partition =
       partitionHandlers(router.currentHandlerInfos || [], handlerInfos);
 
@@ -490,28 +483,6 @@
           context = handlerInfo.context;
 
       callback(handler, context);
-    }
-  }
-
-  /**
-    @private
-
-    Updates the `handler` field in each element in an Array of
-    `UnresolvedHandlerInfo`s from a handler name to a resolved handler.
-
-    When done, the Array will contain `HandlerInfo` structures.
-
-    @param {Router} router
-    @param {Array[UnresolvedHandlerInfo]} handlerInfos
-  */
-  function resolveHandlers(router, handlerInfos) {
-    var handlerInfo;
-
-    for (var i=0, l=handlerInfos.length; i<l; i++) {
-      handlerInfo = handlerInfos[i];
-
-      handlerInfo.name = handlerInfo.handler;
-      handlerInfo.handler = router.getHandler(handlerInfo.handler);
     }
   }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,16 +8,10 @@
   * `{String} handler`: A handler name
   * `{Object} params`: A hash of recognized parameters
 
-  ## `UnresolvedHandlerInfo`
-
-  * `{Boolean} isDynamic`: whether a handler has any dynamic segments
-  * `{String} name`: the name of a handler
-  * `{Object} context`: the active context for the handler
-
   ## `HandlerInfo`
 
   * `{Boolean} isDynamic`: whether a handler has any dynamic segments
-  * `{String} name`: the original unresolved handler name
+  * `{String} name`: the name of a handler
   * `{Object} handler`: a handler object
   * `{Object} context`: the active context for the handler
 */
@@ -66,8 +60,7 @@ Router.prototype = {
     @return {Array} an Array of `[handler, parameter]` tuples
   */
   handleURL: function(url) {
-    var results = this.recognizer.recognize(url),
-        objects = [];
+    var results = this.recognizer.recognize(url);
 
     if (!results) {
       throw new Error("No route matched the URL '" + url + "'");
@@ -223,8 +216,8 @@ Router.prototype = {
 
       toSetup.push({
         isDynamic: !!handlerObj.names.length,
-        handler: handlerObj.handler,
-        name: handlerObj.name,
+        name: handlerObj.handler,
+        handler: handler,
         context: object
       });
     }
@@ -392,7 +385,8 @@ function collectObjects(router, results, index, objects) {
 
     var updatedObjects = objects.concat([{
       context: value,
-      handler: result.handler,
+      name: result.handler,
+      handler: router.getHandler(result.handler),
       isDynamic: result.isDynamic
     }]);
     collectObjects(router, results, index + 1, updatedObjects);
@@ -402,8 +396,9 @@ function collectObjects(router, results, index, objects) {
 /**
   @private
 
-  Takes an Array of `UnresolvedHandlerInfo`s, resolves the handler names
-  into handlers, and then figures out what to do with each of the handlers.
+  Takes an Array of `HandlerInfo`s, figures out which ones are
+  exiting, entering, or changing contexts, and calls the
+  proper handler hooks.
 
   For example, consider the following tree of handlers. Each handler is
   followed by the URL segment it handles.
@@ -437,11 +432,9 @@ function collectObjects(router, results, index, objects) {
      4. Triggers the `setup` callback on `about`
 
   @param {Router} router
-  @param {Array[UnresolvedHandlerInfo]} handlerInfos
+  @param {Array[HandlerInfo]} handlerInfos
 */
 function setupContexts(router, handlerInfos) {
-  resolveHandlers(router, handlerInfos);
-
   var partition =
     partitionHandlers(router.currentHandlerInfos || [], handlerInfos);
 
@@ -490,28 +483,6 @@ function eachHandler(handlerInfos, callback) {
         context = handlerInfo.context;
 
     callback(handler, context);
-  }
-}
-
-/**
-  @private
-
-  Updates the `handler` field in each element in an Array of
-  `UnresolvedHandlerInfo`s from a handler name to a resolved handler.
-
-  When done, the Array will contain `HandlerInfo` structures.
-
-  @param {Router} router
-  @param {Array[UnresolvedHandlerInfo]} handlerInfos
-*/
-function resolveHandlers(router, handlerInfos) {
-  var handlerInfo;
-
-  for (var i=0, l=handlerInfos.length; i<l; i++) {
-    handlerInfo = handlerInfos[i];
-
-    handlerInfo.name = handlerInfo.handler;
-    handlerInfo.handler = router.getHandler(handlerInfo.handler);
   }
 }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -237,7 +237,7 @@ test("A delegate provided to router.js is passed along to route-recognizer", fun
 
   router.handleURL("/posts");
 
-  deepEqual(handlers, ["application", "posts", "posts.index", "loading", "application", "posts", "posts.index"]);
+  deepEqual(handlers, [ "application", "application", "posts", "posts", "posts.index", "posts.index", "loading" ]);
 });
 
 asyncTest("Handling a nested URL triggers each handler", function() {


### PR DESCRIPTION
Now there's just HandlerInfo. No awkward switch between "handler" being a string in `UnresolvedHandlerInfo` and then converting to a similar object where handler is suddenly a function and name is the string. 

Note: the test case that was rearranged was done so because the original test was hard-wired to a particular implementation. The order of the array doesn't matter; the membership of all the elements does, and that's unchanged.
