### PR TITLE
Rewrite/refactor of router.js. Multiple features. 

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -21,10 +21,124 @@ define("router",
     */
 
 
+    function Transition(router, handlerInfos, updateURLMethod) {
+      this.router = router;
+      this.handlerInfos = handlerInfos;
+      this.updateURLMethod = updateURLMethod;
+      this.numPromises = 0;
+      this.resolvedContexts = [];
+    }
+
+    Transition.prototype = {
+  
+      /**
+        Perform the transition.
+      */
+      start: function() { this._step(0); },
+
+      /**
+        @private
+
+        This updates the URL for `transitionTo` once
+        the transition is complete and all context
+        promises (if any) have been resolved.
+      */
+      _updateURL: function() {
+        if (!this.finished || this.numPromises !== 0 || !this.updateURLMethod || this.updatedURL) { return; }
+        var url = urlForObjects(this.router, this.handlerInfos, this.resolvedContexts, true);
+        this.updateURLMethod.call(this.router, url);
+        this.updatedURL = true;
+      },
+
+      /**
+        @private
+
+        This function steps through the transition process,
+        pausing along the way if promise contexts are 
+        encounter (and a loading state is available).
+
+        Takes an array of functions that, when called, yield
+        a `HandlerInfo` that'll be used to build up the final
+        array of `HandlerInfo`s to be passed to `setupContexts`.
+
+        If the context provided in a `HandlerInfo` is a promise
+        (i.e. has a method called `then`), and a 'loading' 
+        handler has been provided, this function will pause
+        until the promise is resolved. Otherwise, the function
+        will proceed with the transition even if the context
+        is a promise.
+      */
+      _step: function(index) {
+        if(index === this.handlerInfos.length) {
+          exitLoadingState(this.router);
+          setupContexts(this.router, this.handlerInfos);
+
+          this.finished = true;
+          this._updateURL();
+          return;
+        }
+
+        var self = this,
+            handlerInfo = this.handlerInfos[index],
+            context = handlerInfo.context(),
+            resolvedContextsIndex = this.resolvedContexts.length;
+
+        if (context && typeof context.then === 'function') {
+          if (handlerInfo.isDynamic && this.updateURLMethod) {
+            // We'll still need to update the URL at the end of this
+            // transition, after all contexts have resolved.
+
+            // Reserve a spot for this context. It will be replaced later.
+            // A leafier route's context may resolve before a parent context, 
+            // so we have to be careful to preserve the ordering.
+            this.numPromises++;
+            this.resolvedContexts[resolvedContextsIndex] = context;
+            context.then(function(value) {
+              self.numPromises--;
+              self.resolvedContexts[resolvedContextsIndex] = value;
+              self._updateURL();
+            });
+          }
+
+          if (enterLoadingState(this.router, handlerInfo.name)) {
+            // We've entered the loading state associated with this route, so
+            // set up a promise so we can leave the loading state once it's resolved.
+            // The chained `then` means that we can also catch errors that happen in `proceed`
+            context.then(proceed).then(null, function(error) {
+              enterFailureState(self.router, error);
+            });
+          } else {
+            // No loading state associated with this route, so continue
+            // transitioning without waiting for promise to resolve.
+            proceed(context);
+          }
+        } else {
+          if (handlerInfo.isDynamic && this.updateURLMethod) {
+            this.resolvedContexts[resolvedContextsIndex] = context;
+          }
+          proceed(context);
+        }
+
+        function proceed(value) {
+          handlerInfo.context = value;
+
+          if (handlerInfo.isDynamic) { 
+            self.resolvedContexts[resolvedContextsIndex] = handlerInfo.context;
+          }
+
+          var handler = handlerInfo.handler;
+          if (handler.context !== handlerInfo.context) {
+            setContext(handler, handlerInfo.context);
+          }
+
+          self._step(index + 1);
+        }
+      }
+    };
+
     function Router() {
       this.recognizer = new RouteRecognizer();
     }
-
 
     Router.prototype = {
       /**
@@ -52,24 +166,60 @@ define("router",
 
       /**
         The entry point for handling a change to the URL (usually
-        via the back and forward button).
-
-        Returns an Array of handlers and the parameters associated
-        with those parameters.
+        via the back and forward button). This will perform a transition
+        into the handlers that match the provided URL unless the 
+        transition is halted or redirected by a handler's
+        TransitionEvent handlers.
 
         @param {String} url a URL to process
-
-        @return {Array} an Array of `[handler, parameter]` tuples
       */
       handleURL: function(url) {
         var results = this.recognizer.recognize(url);
 
-        if (!results) {
+        // URL-less routes should also not be recognized.
+        if (!results || this.getHandler(results[results.length - 1].handler).notAccessibleByURL) {
           throw new Error("No route matched the URL '" + url + "'");
         }
 
-        collectObjects(this, results, 0, []);
+        var handlerInfos = [], router = this;
+        for (var i = 0; i < results.length; i += 1) {
+          var result = results[i], name = result.handler, handler = router.getHandler(name);
+
+          handlerInfos.push({ 
+            isDynamic: result.isDynamic, 
+            handler: handler, 
+            name: name, 
+            context: getHandleURLContextResolver(handler, result.params)
+          });
+        }
+
+        if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+        var transition = new Transition(this, handlerInfos);
+        transition.start();
       },
+
+
+      /**
+        Configure whether `updateURL`/`replaceURL` should be called
+        immediately at the beginning of `transitionTo` or whether
+        it should wait until all promises are resolved. 
+
+        The default behavior (null) is optimistic;
+        it will try to change the URL right away, but if a URL
+        can't be serialized, it'll wait until all promises are
+        resolved and try again later. 
+
+        When set to true (aggressive), the URL is changed immediately,
+        and if a URL can't be serialized, an Error will be raised.
+
+        When set to false, the URL will only be changed at the
+        very end of a `transitionTo`, after all promises have
+        resolved.
+
+        @param {String} url a URL to update to
+      */
+      updateURLImmediately: null,
 
       /**
         Hook point for updating the URL.
@@ -100,8 +250,10 @@ define("router",
         @param {String} name the name of the route
       */
       transitionTo: function(name) {
-        var args = Array.prototype.slice.call(arguments, 1);
-        doTransition(this, name, this.updateURL, args);
+        var objects = Array.prototype.slice.call(arguments, 1),
+            transition = getDirectTransition(this, name, objects, this.updateURL);
+        if(!transition) { return; }
+        transition.start();
       },
 
       /**
@@ -113,8 +265,10 @@ define("router",
         @param {String} name the name of the route
       */
       replaceWith: function(name) {
-        var args = Array.prototype.slice.call(arguments, 1);
-        doTransition(this, name, this.replaceURL, args);
+        var objects = Array.prototype.slice.call(arguments, 1),
+            transition = getDirectTransition(this, name, objects, this.replaceURL);
+        if(!transition) { return; }
+        transition.start();
       },
 
       /**
@@ -127,9 +281,50 @@ define("router",
         @param {Array[Object]} contexts
         @return {Object} a serialized parameter hash
       */
-      paramsForHandler: function(handlerName, callback) {
-        var output = this._paramsForHandler(handlerName, [].slice.call(arguments, 1));
-        return output.params;
+      paramsForHandler: function(handlerName) {
+        var handlers = this.recognizer.handlersFor(handlerName),
+            objects = [].slice.call(arguments, 1),
+            params = {},
+            objectsToMatch = objects.length,
+            startIdx = handlers.length,
+            object, objectChanged, handlerObj, handler, names, i;
+
+        // Find out which handler to start matching at
+        for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+          if (handlers[i].names.length) {
+            objectsToMatch--;
+            startIdx = i;
+          }
+        }
+
+        if (objectsToMatch > 0) {
+          throw "More objects were passed than dynamic segments";
+        }
+
+        // Connect the objects to the routes
+        for (i=0; i<handlers.length; i++) {
+          handlerObj = handlers[i];
+          handler = this.getHandler(handlerObj.handler);
+          names = handlerObj.names;
+
+          // If it's a dynamic segment
+          if (handlerObj.names.length) {
+            // If we have objects, use them
+            if (i >= startIdx) {
+              object = objects.shift();
+            // Otherwise use existing context
+            } else {
+              object = handler.context;
+            }
+
+            // Serialize to generate params
+            if (handler.serialize) {
+              merge(params, handler.serialize(object, handlerObj.names));
+            }
+          } 
+        }
+
+        return params;
       },
 
       /**
@@ -145,98 +340,6 @@ define("router",
       generate: function(handlerName) {
         var params = this.paramsForHandler.apply(this, arguments);
         return this.recognizer.generate(handlerName, params);
-      },
-
-      /**
-        @private
-
-        Used internally by `generate` and `transitionTo`.
-      */
-      _paramsForHandler: function(handlerName, objects, doUpdate) {
-        var handlers = this.recognizer.handlersFor(handlerName),
-            params = {},
-            toSetup = [],
-            startIdx = handlers.length,
-            objectsToMatch = objects.length,
-            object, objectChanged, handlerObj, handler, names, i;
-
-        // Find out which handler to start matching at
-        for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
-          if (handlers[i].names.length) {
-            objectsToMatch--;
-            startIdx = i;
-          }
-        }
-
-        if (objectsToMatch > 0) {
-          throw "More context objects were passed than there are dynamic segments for the route: "+handlerName;
-        }
-
-        // Connect the objects to the routes
-        for (i=0; i<handlers.length; i++) {
-          handlerObj = handlers[i];
-          handler = this.getHandler(handlerObj.handler);
-          names = handlerObj.names;
-          objectChanged = false;
-
-          // If it's a dynamic segment
-          if (names.length) {
-            // If we have objects, use them
-            if (i >= startIdx) {
-              object = objects.shift();
-              objectChanged = true;
-            // Otherwise use existing context
-            } else {
-              object = handler.context;
-            }
-
-            // Serialize to generate params
-            if (handler.serialize) {
-              merge(params, handler.serialize(object, names));
-            }
-          // If it's not a dynamic segment and we're updating
-          } else if (doUpdate) {
-            // If we've passed the match point we need to deserialize again
-            // or if we never had a context
-            if (i > startIdx || !handler.hasOwnProperty('context')) {
-              if (handler.deserialize) {
-                object = handler.deserialize({});
-                objectChanged = true;
-              }
-            // Otherwise use existing context
-            } else {
-              object = handler.context;
-            }
-          }
-
-          // Make sure that we update the context here so it's available to
-          // subsequent deserialize calls
-          if (doUpdate && objectChanged) {
-            // TODO: It's a bit awkward to set the context twice, see if we can DRY things up
-            setContext(handler, object);
-          }
-
-          toSetup.push({
-            isDynamic: !!handlerObj.names.length,
-            name: handlerObj.handler,
-            handler: handler,
-            context: object
-          });
-
-          if (i === handlers.length - 1) {
-            var lastHandler = toSetup[toSetup.length - 1],
-                additionalHandler;
-
-            if (additionalHandler = lastHandler.handler.additionalHandler) {
-              handlers.push({
-                handler: additionalHandler.call(lastHandler.handler),
-                names: []
-              });
-            }
-          }
-        }
-
-        return { params: params, toSetup: toSetup };
       },
 
       isActive: function(handlerName) {
@@ -281,25 +384,33 @@ define("router",
     /**
       @private
 
-      This function is called the first time the `collectObjects`
-      function encounters a promise while converting URL parameters
-      into objects.
+      This function will resolve the `loading` handler, if one has
+      been specified, and trigger `enter` and `setup` on it if
+      the router has not already entered the loading state for 
+      this particular transition.
 
-      It triggers the `enter` and `setup` methods on the `loading`
-      handler.
+      Returns true if a `loading` handler exists, else false.
+      This return value is used to determine whether a transition
+      should pause when a promise context is encountered,
+      for both `transitionTo` and `handleURL` transitions.
+      If true (`loading` handler was found), the transition 
+      will pause for both transition types and only continue
+      once the promise has been resolved. If false, the 
+      transition will continue without pausing.
 
       @param {Router} router
+      @return {Boolean} true if loading state exists, else false
     */
-    function loading(router) {
+    function enterLoadingState(router) {
+      var handler = router.getHandler('loading');
+      if(!handler) { return false; }
+
       if (!router.isLoading) {
         router.isLoading = true;
-        var handler = router.getHandler('loading');
-
-        if (handler) {
-          if (handler.enter) { handler.enter(); }
-          if (handler.setup) { handler.setup(); }
-        }
+        if (handler.enter) { handler.enter(); }
+        if (handler.setup) { handler.setup(); }
       }
+      return true;
     }
 
     /**
@@ -308,11 +419,12 @@ define("router",
       This function is called if a promise was previously
       encountered once all promises are resolved.
 
-      It triggers the `exit` method on the `loading` handler.
+      It triggers the `exit` method on the `loading` handler,
+      if one exists.
 
       @param {Router} router
     */
-    function loaded(router) {
+    function exitLoadingState(router) {
       router.isLoading = false;
       var handler = router.getHandler('loading');
       if (handler && handler.exit) { handler.exit(); }
@@ -324,9 +436,8 @@ define("router",
       This function is called if any encountered promise
       is rejected.
 
-      It triggers the `exit` method on the `loading` handler,
-      the `enter` method on the `failure` handler, and the
-      `setup` method on the `failure` handler with the
+      It triggers the `exit` method on the `loading` handler
+      and the `setup` method on the `failure` handler with the
       `error`.
 
       @param {Router} router
@@ -334,89 +445,123 @@ define("router",
         rejection, to pass into the failure handler's
         `setup` method.
     */
-    function failure(router, error) {
-      loaded(router);
+    function enterFailureState(router, error) {
+      exitLoadingState(router);
       var handler = router.getHandler('failure');
+      if (handler && handler.enter) { handler.enter(error); }
       if (handler && handler.setup) { handler.setup(error); }
     }
 
     /**
       @private
+
+      This function generates and returns a Transition object based 
+      on the handler name and context objects provided, or returns
+      null if the transition was halted or redirected.
+
+      @param {Router} router
+      @param {String} name The name of the target handler to
+        transition into.
+      @param {Array} objects the context objects to be passed
+        to handlers with dynamic parameters.
+      @param {Function} updateURLMethod `updateURL` or `replaceURL`,
+        the method used for changing the URL to reflect this transition.
     */
-    function doTransition(router, name, method, args) {
-      var output = router._paramsForHandler(name, args, true);
-      var params = output.params, toSetup = output.toSetup;
+    function getDirectTransition(router, name, objects, updateURLMethod) {
 
-      var url = router.recognizer.generate(name, params);
-      method.call(router, url);
+      var handlers = router.recognizer.handlersFor(name),
+          startIdx = handlers.length,
+          objectsToMatch = objects.length,
+          i, len;
 
-      setupContexts(router, toSetup);
+      // Find out which handler to start matching at
+      for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+        if (handlers[i].names.length) {
+          objectsToMatch--;
+          startIdx = i;
+        }
+      }
+
+      if (objectsToMatch > 0) {
+        throw "More objects were passed than dynamic segments";
+      }
+
+      var handlerInfos = [], objectIndex = 0;
+      for (i=0, len=handlers.length; i<len; i++) {
+        var handlerObj = handlers[i],
+            handlerName = handlerObj.handler,
+            handler = router.getHandler(handlerName),
+            isDynamic = !!handlerObj.names.length,
+            objectToUse = null;
+
+        if(isDynamic && i >= startIdx) {
+          objectToUse = objects[objectIndex++];
+        }
+
+        handlerInfos.push({ 
+          isDynamic: isDynamic, 
+          handler: handler, 
+          name: handlerName, 
+          context: getTransitionToContextResolver(isDynamic, i, startIdx, objectToUse, handler)
+        });
+      }
+
+      if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+      if (handlerInfos[handlerInfos.length - 1].handler.notAccessibleByURL) {
+        // This is a URL-less transition, so don't attempt to change the URL.
+        updateURLMethod = null;
+      }
+
+      if (updateURLMethod && router.updateURLImmediately !== false) {
+        // Attempt to generate the new URL immediately.
+        var url = urlForObjects(router, handlerInfos, objects, router.updateURLImmediately === true);
+        if(url) {
+          // Perform the URL change and prevent the Transition from doing it later.
+          updateURLMethod.call(router, url);
+          updateURLMethod = null;
+        }
+      }
+
+      return new Transition(router, handlerInfos, updateURLMethod);
     }
+
 
     /**
       @private
+ 
+      This function as called at the end of a 
+      `transitionTo` transition to perform the update to the 
+      URL. This function will fail and return false if 
+      a valid URL cannot be serialized by the context
+      objects provided, which can happen if `serialize`
+      is called with a promise which doesn't have enough
+      information on it to generate a URL param. 
 
-      This function is called after a URL change has been handled
-      by `router.handleURL`.
+      This function is used twice: once at the beginning
+      of a `transitionTo` to immediately attempt a URL
+      change
 
-      Takes an Array of `RecognizedHandler`s, and converts the raw
-      params hashes into deserialized objects by calling deserialize
-      on the handlers. This process builds up an Array of
-      `HandlerInfo`s. It then calls `setupContexts` with the Array.
-
-      If the `deserialize` method on a handler returns a promise
-      (i.e. has a method called `then`), this function will pause
-      building up the `HandlerInfo` Array until the promise is
-      resolved. It will use the resolved value as the context of
-      `HandlerInfo`.
     */
-    function collectObjects(router, results, index, objects) {
-      if (results.length === index) {
-        var lastObject = objects[objects.length - 1],
-            lastHandler = lastObject && lastObject.handler;
+    function urlForObjects(router, handlerInfos, objects, errorOnFailure) {
+      var lastHandlerName = handlerInfos[handlerInfos.length - 1].name,
+          params = router.paramsForHandler.apply(router, [lastHandlerName].concat(objects));
 
-        if (lastHandler && lastHandler.additionalHandler) {
-          var additionalResult = {
-            handler: lastHandler.additionalHandler(),
-            params: {},
-            isDynamic: false
-          };
-          results.push(additionalResult);
-        } else {
-          loaded(router);
-          setupContexts(router, objects);
-          return;
+      // Validate that the paramsForHandler did return invalid parameters, e.g.
+      // parameters with null/undefined values.
+      for (var key in params) {
+        if (!params.hasOwnProperty(key)) { continue; }
+
+        var value = params[key];
+        if (typeof value === "undefined" || value === null) {
+          if (errorOnFailure) {
+            throw new Error("Could not generate URL. Check that your serialize functions aren't populating the params hash with undefined/null values.");
+          } else {
+            return null;
+          }
         }
       }
-
-      var result = results[index];
-      var handler = router.getHandler(result.handler);
-      var object = handler.deserialize && handler.deserialize(result.params);
-
-      if (object && typeof object.then === 'function') {
-        loading(router);
-
-        // The chained `then` means that we can also catch errors that happen in `proceed`
-        object.then(proceed).then(null, function(error) {
-          failure(router, error);
-        });
-      } else {
-        proceed(object);
-      }
-
-      function proceed(value) {
-        if (handler.context !== object) {
-          setContext(handler, object);
-        }
-
-        var updatedObjects = objects.concat([{
-          context: value,
-          name: result.handler,
-          handler: router.getHandler(result.handler),
-          isDynamic: result.isDynamic
-        }]);
-        collectObjects(router, results, index + 1, updatedObjects);
-      }
+      return router.recognizer.generate(lastHandlerName, params);
     }
 
     /**
@@ -480,7 +625,9 @@ define("router",
       eachHandler(partition.entered, function(handler, context) {
         if (aborted) { return; }
         if (handler.enter) { handler.enter(); }
+
         setContext(handler, context);
+
         if (handler.setup) {
           if (false === handler.setup(context)) {
             aborted = true;
@@ -488,6 +635,7 @@ define("router",
         }
       });
 
+      // Perform post-transition client hook.
       if (router.didTransition) {
         router.didTransition(handlerInfos);
       }
@@ -610,5 +758,192 @@ define("router",
       handler.context = context;
       if (handler.contextDidChange) { handler.contextDidChange(); }
     }
+
+    /**
+      This is the transition event passed to transition handlers, used
+      for cancelling or redirecting an intended transition.
+    */
+    function TransitionEvent(router, handlerInfos) {
+      this.router = router;
+      this.handlerInfos = handlerInfos;
+      this.currentIndex = 0;
+    }
+
+    /**
+      The `TransitionEvent` prototype contains all the public API
+      for transition event handlers declared in the `transitions`
+      hash of the handler. 
+     */
+    TransitionEvent.prototype = {
+      /**
+        Halts the attempted transition and forwards arguments to
+        the router's `transitionTo`. Use this function to halt
+        and redirect a transition elsewhere.
+       */
+      transitionTo: function() {
+        this.preventTransition();
+        this.router.transitionTo.apply(this.router, arguments);
+      },
+
+      /**
+        Halts the attempted transition.
+       */
+      preventTransition: function() {
+        this.transitionCancelled = true;
+      },
+
+      /**
+        Returns the context object for this handler. 
+       */
+      getContext: function() {
+        if(this.isDestinationRoute) {
+          return this.handlerInfos[this.currentIndex].context();
+        } else {
+          throw new Error("getContext() can only be called from within destination routes.");
+        }
+      }
+    };
+
+    /**
+      @private
+
+      Executes all matching transition event handlers defined
+      in the `transitions` hash on the handlers. Halts the
+      algorithm and returns false if any one of the handlers
+      prevented or redirected the transition.
+
+      Order of handler execution is as follows:
+      1) Execute source handlers leaf to root
+      2) Execute destination handlers from leaf to root
+     */
+    function runTransitionHandlers(router, destHandlerInfos) {
+      var transitionEvent = new TransitionEvent(router, destHandlerInfos),
+          sourceHandlerInfos = router.currentHandlerInfos, i;
+
+      // sourceHandlerInfos won't exist for very first transition.
+      if(sourceHandlerInfos) {
+        for (i = sourceHandlerInfos.length - 1; i >= 0; i--) {
+          if(!processTransitionRules(true, sourceHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+            return false;
+          }
+        }
+      }
+
+      if (transitionEvent.transitionCancelled) { return false; }
+      transitionEvent.isDestinationRoute = true;
+
+      for (i = 0; i < destHandlerInfos.length; i++) {
+        // Update the current context index on the transitionEvent
+        // so that getContext() will return the correct one. 
+        transitionEvent.currentIndex = i;
+        if(!processTransitionRules(false, destHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    /**
+      @private
+
+      Runs matching transition event handlers for a given `handlerInfo`.
+      Returns false if the transition was halted or redirected, else true.
+     */
+    function processTransitionRules(checkingSourceRoutes, handlerInfo, sourceHandlerInfos, destHandlerInfos, transitionEvent) {
+      var handler = handlerInfo.handler, transitions = handler.transitions;
+      if(!transitions) { return true; }
+
+      for (var transitionRule in transitions) {
+        if (!transitions.hasOwnProperty(transitionRule)) { continue; }
+
+        var split = transitionRule.split(' '), fromTo = split[0], routeName = split[1], 
+            runHandler = null, handlerInfosToCheck = null;
+    
+        if (fromTo === 'to') {
+          if (checkingSourceRoutes) {
+            if (routeName === '*' && sourceHandlerInfos) {
+              runHandler = !checkHandlerMembership(handlerInfo.name, destHandlerInfos);
+            } else {
+              runHandler = checkHandlerMembership(routeName, destHandlerInfos);
+            }
+          }
+        } else if (fromTo === 'from') {
+          if (!checkingSourceRoutes) {
+            if (routeName === '*') {
+              runHandler = !checkHandlerMembership(handlerInfo.name, sourceHandlerInfos);
+            } else if (sourceHandlerInfos) {
+              runHandler = checkHandlerMembership(routeName, sourceHandlerInfos);
+            }
+          }
+        } else {
+          throw new Error("Badly formed transition handler key (expected 'to' or 'from'): " + transitionRule);
+        }
+
+        if (runHandler) {
+          var transitionHandler = transitions[transitionRule];
+          transitionHandler.call(handler, transitionEvent);
+
+          if(transitionEvent.transitionCancelled) { return false; }
+        }
+      }
+      return true;
+    }
+
+    function checkHandlerMembership(routeName, handlerInfos) {
+      for (var i = 0; i < handlerInfos.length; i += 1) {
+        if(handlerInfos[i].name === routeName) { return true; }
+      }
+      return false;
+    }
+
+    /**
+      @private
+
+      Returns a function that returns the context to use for
+      the provided `handler`. This is used for `handleURL`
+      transitions, and therefore makes use of the handler's
+      `deserialize` function to determine the context to use.
+     */
+    function getHandleURLContextResolver(handler, params) {
+      var cachedContext;
+      return function() {
+        if(cachedContext) { return cachedContext; }
+        return cachedContext = handler.deserialize && handler.deserialize(params);
+      };
+    }
+
+    /**
+      @private
+
+      Returns a function that returns the context to use for
+      the provided `handler`. This is used for `transitionTo`
+      transitions.
+     */
+    function getTransitionToContextResolver(isDynamic, index, startIndex, object, handler) {
+      var cachedContext;
+      return function() {
+        if(cachedContext) { return cachedContext; }
+
+        if (isDynamic) {
+          if(index < startIndex) {
+            object = handler.context;
+          }
+        } else {
+          // If we've passed the match point we need to deserialize again
+          // or if we never had a context
+          if (index > startIndex || !handler.hasOwnProperty('context')) {
+            if (handler.deserialize) {
+              object = handler.deserialize({});
+            }
+          // Otherwise use existing context
+          } else {
+            object = handler.context;
+          }
+        }
+        return cachedContext = object;
+      };
+    }
+
     return Router;
   });

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -19,6 +19,122 @@ var RouteRecognizer = require("route-recognizer");
 */
 
 
+function Transition(router, handlerInfos, updateURLMethod) {
+  this.router = router;
+  this.handlerInfos = handlerInfos;
+  this.updateURLMethod = updateURLMethod;
+  this.numPromises = 0;
+  this.resolvedContexts = [];
+}
+
+Transition.prototype = {
+  
+  /**
+    Perform the transition.
+  */
+  start: function() { this._step(0); },
+
+  /**
+    @private
+
+    This updates the URL for `transitionTo` once
+    the transition is complete and all context
+    promises (if any) have been resolved.
+  */
+  _updateURL: function() {
+    if (!this.finished || this.numPromises !== 0 || !this.updateURLMethod || this.updatedURL) { return; }
+    var url = urlForObjects(this.router, this.handlerInfos, this.resolvedContexts, true);
+    this.updateURLMethod.call(this.router, url);
+    this.updatedURL = true;
+  },
+
+  /**
+    @private
+
+    This function steps through the transition process,
+    pausing along the way if promise contexts are 
+    encounter (and a loading state is available).
+
+    Takes an array of functions that, when called, yield
+    a `HandlerInfo` that'll be used to build up the final
+    array of `HandlerInfo`s to be passed to `setupContexts`.
+
+    If the context provided in a `HandlerInfo` is a promise
+    (i.e. has a method called `then`), and a 'loading' 
+    handler has been provided, this function will pause
+    until the promise is resolved. Otherwise, the function
+    will proceed with the transition even if the context
+    is a promise.
+  */
+  _step: function(index) {
+    if(index === this.handlerInfos.length) {
+      exitLoadingState(this.router);
+      setupContexts(this.router, this.handlerInfos);
+
+      this.finished = true;
+      this._updateURL();
+      return;
+    }
+
+    var self = this,
+        handlerInfo = this.handlerInfos[index],
+        context = handlerInfo.context(),
+        resolvedContextsIndex = this.resolvedContexts.length;
+
+    if (context && typeof context.then === 'function') {
+      if (handlerInfo.isDynamic && this.updateURLMethod) {
+        // We'll still need to update the URL at the end of this
+        // transition, after all contexts have resolved.
+
+        // Reserve a spot for this context. It will be replaced later.
+        // A leafier route's context may resolve before a parent context, 
+        // so we have to be careful to preserve the ordering.
+        this.numPromises++;
+        this.resolvedContexts[resolvedContextsIndex] = context;
+        context.then(function(value) {
+          self.numPromises--;
+          self.resolvedContexts[resolvedContextsIndex] = value;
+          self._updateURL();
+        });
+      }
+
+      if (enterLoadingState(this.router, handlerInfo.name)) {
+        // We've entered the loading state associated with this route, so
+        // set up a promise so we can leave the loading state once it's resolved.
+        // The chained `then` means that we can also catch errors that happen in `proceed`
+        context.then(proceed).then(null, function(error) {
+          enterFailureState(self.router, error);
+        });
+      } else {
+        // No loading state associated with this route, so continue
+        // transitioning without waiting for promise to resolve.
+        proceed(context);
+      }
+    } else {
+      if (handlerInfo.isDynamic && this.updateURLMethod) {
+        this.resolvedContexts[resolvedContextsIndex] = context;
+      }
+      proceed(context);
+    }
+
+    function proceed(value) {
+      handlerInfo.context = value;
+
+      if (handlerInfo.isDynamic) { 
+        self.resolvedContexts[resolvedContextsIndex] = handlerInfo.context;
+      }
+
+      var handler = handlerInfo.handler;
+      if (handler.context !== handlerInfo.context) {
+        setContext(handler, handlerInfo.context);
+      }
+
+      self._step(index + 1);
+    }
+  }
+};
+
+
 function Router() {
   this.recognizer = new RouteRecognizer();
 }
@@ -50,24 +166,60 @@ Router.prototype = {
 
   /**
     The entry point for handling a change to the URL (usually
-    via the back and forward button).
-
-    Returns an Array of handlers and the parameters associated
-    with those parameters.
+    via the back and forward button). This will perform a transition
+    into the handlers that match the provided URL unless the 
+    transition is halted or redirected by a handler's
+    TransitionEvent handlers.
 
     @param {String} url a URL to process
-
-    @return {Array} an Array of `[handler, parameter]` tuples
   */
   handleURL: function(url) {
     var results = this.recognizer.recognize(url);
 
-    if (!results) {
+    // URL-less routes should also not be recognized.
+    if (!results || this.getHandler(results[results.length - 1].handler).notAccessibleByURL) {
       throw new Error("No route matched the URL '" + url + "'");
     }
 
-    collectObjects(this, results, 0, []);
+    var handlerInfos = [], router = this;
+    for (var i = 0; i < results.length; i += 1) {
+      var result = results[i], name = result.handler, handler = router.getHandler(name);
+
+      handlerInfos.push({ 
+        isDynamic: result.isDynamic, 
+        handler: handler, 
+        name: name, 
+        context: getHandleURLContextResolver(handler, result.params)
+      });
+    }
+
+    if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+    var transition = new Transition(this, handlerInfos);
+    transition.start();
   },
+
+
+  /**
+    Configure whether `updateURL`/`replaceURL` should be called
+    immediately at the beginning of `transitionTo` or whether
+    it should wait until all promises are resolved. 
+
+    The default behavior (null) is optimistic;
+    it will try to change the URL right away, but if a URL
+    can't be serialized, it'll wait until all promises are
+    resolved and try again later. 
+
+    When set to true (aggressive), the URL is changed immediately,
+    and if a URL can't be serialized, an Error will be raised.
+
+    When set to false, the URL will only be changed at the
+    very end of a `transitionTo`, after all promises have
+    resolved.
+
+    @param {String} url a URL to update to
+  */
+  updateURLImmediately: null,
 
   /**
     Hook point for updating the URL.
@@ -98,8 +250,10 @@ Router.prototype = {
     @param {String} name the name of the route
   */
   transitionTo: function(name) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    doTransition(this, name, this.updateURL, args);
+    var objects = Array.prototype.slice.call(arguments, 1),
+        transition = getDirectTransition(this, name, objects, this.updateURL);
+    if(!transition) { return; }
+    transition.start();
   },
 
   /**
@@ -111,8 +265,10 @@ Router.prototype = {
     @param {String} name the name of the route
   */
   replaceWith: function(name) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    doTransition(this, name, this.replaceURL, args);
+    var objects = Array.prototype.slice.call(arguments, 1),
+        transition = getDirectTransition(this, name, objects, this.replaceURL);
+    if(!transition) { return; }
+    transition.start();
   },
 
   /**
@@ -125,9 +281,50 @@ Router.prototype = {
     @param {Array[Object]} contexts
     @return {Object} a serialized parameter hash
   */
-  paramsForHandler: function(handlerName, callback) {
-    var output = this._paramsForHandler(handlerName, [].slice.call(arguments, 1));
-    return output.params;
+  paramsForHandler: function(handlerName) {
+    var handlers = this.recognizer.handlersFor(handlerName),
+        objects = [].slice.call(arguments, 1),
+        params = {},
+        objectsToMatch = objects.length,
+        startIdx = handlers.length,
+        object, objectChanged, handlerObj, handler, names, i;
+
+    // Find out which handler to start matching at
+    for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+      if (handlers[i].names.length) {
+        objectsToMatch--;
+        startIdx = i;
+      }
+    }
+
+    if (objectsToMatch > 0) {
+      throw "More objects were passed than dynamic segments";
+    }
+
+    // Connect the objects to the routes
+    for (i=0; i<handlers.length; i++) {
+      handlerObj = handlers[i];
+      handler = this.getHandler(handlerObj.handler);
+      names = handlerObj.names;
+
+      // If it's a dynamic segment
+      if (handlerObj.names.length) {
+        // If we have objects, use them
+        if (i >= startIdx) {
+          object = objects.shift();
+        // Otherwise use existing context
+        } else {
+          object = handler.context;
+        }
+
+        // Serialize to generate params
+        if (handler.serialize) {
+          merge(params, handler.serialize(object, handlerObj.names));
+        }
+      } 
+    }
+
+    return params;
   },
 
   /**
@@ -143,98 +340,6 @@ Router.prototype = {
   generate: function(handlerName) {
     var params = this.paramsForHandler.apply(this, arguments);
     return this.recognizer.generate(handlerName, params);
-  },
-
-  /**
-    @private
-
-    Used internally by `generate` and `transitionTo`.
-  */
-  _paramsForHandler: function(handlerName, objects, doUpdate) {
-    var handlers = this.recognizer.handlersFor(handlerName),
-        params = {},
-        toSetup = [],
-        startIdx = handlers.length,
-        objectsToMatch = objects.length,
-        object, objectChanged, handlerObj, handler, names, i;
-
-    // Find out which handler to start matching at
-    for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
-      if (handlers[i].names.length) {
-        objectsToMatch--;
-        startIdx = i;
-      }
-    }
-
-    if (objectsToMatch > 0) {
-      throw "More context objects were passed than there are dynamic segments for the route: "+handlerName;
-    }
-
-    // Connect the objects to the routes
-    for (i=0; i<handlers.length; i++) {
-      handlerObj = handlers[i];
-      handler = this.getHandler(handlerObj.handler);
-      names = handlerObj.names;
-      objectChanged = false;
-
-      // If it's a dynamic segment
-      if (names.length) {
-        // If we have objects, use them
-        if (i >= startIdx) {
-          object = objects.shift();
-          objectChanged = true;
-        // Otherwise use existing context
-        } else {
-          object = handler.context;
-        }
-
-        // Serialize to generate params
-        if (handler.serialize) {
-          merge(params, handler.serialize(object, names));
-        }
-      // If it's not a dynamic segment and we're updating
-      } else if (doUpdate) {
-        // If we've passed the match point we need to deserialize again
-        // or if we never had a context
-        if (i > startIdx || !handler.hasOwnProperty('context')) {
-          if (handler.deserialize) {
-            object = handler.deserialize({});
-            objectChanged = true;
-          }
-        // Otherwise use existing context
-        } else {
-          object = handler.context;
-        }
-      }
-
-      // Make sure that we update the context here so it's available to
-      // subsequent deserialize calls
-      if (doUpdate && objectChanged) {
-        // TODO: It's a bit awkward to set the context twice, see if we can DRY things up
-        setContext(handler, object);
-      }
-
-      toSetup.push({
-        isDynamic: !!handlerObj.names.length,
-        name: handlerObj.handler,
-        handler: handler,
-        context: object
-      });
-
-      if (i === handlers.length - 1) {
-        var lastHandler = toSetup[toSetup.length - 1],
-            additionalHandler;
-
-        if (additionalHandler = lastHandler.handler.additionalHandler) {
-          handlers.push({
-            handler: additionalHandler.call(lastHandler.handler),
-            names: []
-          });
-        }
-      }
-    }
-
-    return { params: params, toSetup: toSetup };
   },
 
   isActive: function(handlerName) {
@@ -279,25 +384,33 @@ function isCurrent(currentHandlerInfos, handlerName) {
 /**
   @private
 
-  This function is called the first time the `collectObjects`
-  function encounters a promise while converting URL parameters
-  into objects.
+  This function will resolve the `loading` handler, if one has
+  been specified, and trigger `enter` and `setup` on it if
+  the router has not already entered the loading state for 
+  this particular transition.
 
-  It triggers the `enter` and `setup` methods on the `loading`
-  handler.
+  Returns true if a `loading` handler exists, else false.
+  This return value is used to determine whether a transition
+  should pause when a promise context is encountered,
+  for both `transitionTo` and `handleURL` transitions.
+  If true (`loading` handler was found), the transition 
+  will pause for both transition types and only continue
+  once the promise has been resolved. If false, the 
+  transition will continue without pausing.
 
   @param {Router} router
+  @return {Boolean} true if loading state exists, else false
 */
-function loading(router) {
+function enterLoadingState(router) {
+  var handler = router.getHandler('loading');
+  if(!handler) { return false; }
+
   if (!router.isLoading) {
     router.isLoading = true;
-    var handler = router.getHandler('loading');
-
-    if (handler) {
-      if (handler.enter) { handler.enter(); }
-      if (handler.setup) { handler.setup(); }
-    }
+    if (handler.enter) { handler.enter(); }
+    if (handler.setup) { handler.setup(); }
   }
+  return true;
 }
 
 /**
@@ -306,11 +419,12 @@ function loading(router) {
   This function is called if a promise was previously
   encountered once all promises are resolved.
 
-  It triggers the `exit` method on the `loading` handler.
+  It triggers the `exit` method on the `loading` handler,
+  if one exists.
 
   @param {Router} router
 */
-function loaded(router) {
+function exitLoadingState(router) {
   router.isLoading = false;
   var handler = router.getHandler('loading');
   if (handler && handler.exit) { handler.exit(); }
@@ -322,9 +436,8 @@ function loaded(router) {
   This function is called if any encountered promise
   is rejected.
 
-  It triggers the `exit` method on the `loading` handler,
-  the `enter` method on the `failure` handler, and the
-  `setup` method on the `failure` handler with the
+  It triggers the `exit` method on the `loading` handler
+  and the `setup` method on the `failure` handler with the
   `error`.
 
   @param {Router} router
@@ -332,89 +445,123 @@ function loaded(router) {
     rejection, to pass into the failure handler's
     `setup` method.
 */
-function failure(router, error) {
-  loaded(router);
+function enterFailureState(router, error) {
+  exitLoadingState(router);
   var handler = router.getHandler('failure');
+  if (handler && handler.enter) { handler.enter(error); }
   if (handler && handler.setup) { handler.setup(error); }
 }
 
 /**
   @private
+
+  This function generates and returns a Transition object based 
+  on the handler name and context objects provided, or returns
+  null if the transition was halted or redirected.
+
+  @param {Router} router
+  @param {String} name The name of the target handler to
+    transition into.
+  @param {Array} objects the context objects to be passed
+    to handlers with dynamic parameters.
+  @param {Function} updateURLMethod `updateURL` or `replaceURL`,
+    the method used for changing the URL to reflect this transition.
 */
-function doTransition(router, name, method, args) {
-  var output = router._paramsForHandler(name, args, true);
-  var params = output.params, toSetup = output.toSetup;
+function getDirectTransition(router, name, objects, updateURLMethod) {
 
-  var url = router.recognizer.generate(name, params);
-  method.call(router, url);
+  var handlers = router.recognizer.handlersFor(name),
+      startIdx = handlers.length,
+      objectsToMatch = objects.length,
+      i, len;
 
-  setupContexts(router, toSetup);
+  // Find out which handler to start matching at
+  for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+    if (handlers[i].names.length) {
+      objectsToMatch--;
+      startIdx = i;
+    }
+  }
+
+  if (objectsToMatch > 0) {
+    throw "More objects were passed than dynamic segments";
+  }
+
+  var handlerInfos = [], objectIndex = 0;
+  for (i=0, len=handlers.length; i<len; i++) {
+    var handlerObj = handlers[i],
+        handlerName = handlerObj.handler,
+        handler = router.getHandler(handlerName),
+        isDynamic = !!handlerObj.names.length,
+        objectToUse = null;
+
+    if(isDynamic && i >= startIdx) {
+      objectToUse = objects[objectIndex++];
+    }
+
+    handlerInfos.push({ 
+      isDynamic: isDynamic, 
+      handler: handler, 
+      name: handlerName, 
+      context: getTransitionToContextResolver(isDynamic, i, startIdx, objectToUse, handler)
+    });
+  }
+
+  if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+  if (handlerInfos[handlerInfos.length - 1].handler.notAccessibleByURL) {
+    // This is a URL-less transition, so don't attempt to change the URL.
+    updateURLMethod = null;
+  }
+
+  if (updateURLMethod && router.updateURLImmediately !== false) {
+    // Attempt to generate the new URL immediately.
+    var url = urlForObjects(router, handlerInfos, objects, router.updateURLImmediately === true);
+    if(url) {
+      // Perform the URL change and prevent the Transition from doing it later.
+      updateURLMethod.call(router, url);
+      updateURLMethod = null;
+    }
+  }
+
+  return new Transition(router, handlerInfos, updateURLMethod);
 }
+
 
 /**
   @private
+ 
+  This function as called at the end of a 
+  `transitionTo` transition to perform the update to the 
+  URL. This function will fail and return false if 
+  a valid URL cannot be serialized by the context
+  objects provided, which can happen if `serialize`
+  is called with a promise which doesn't have enough
+  information on it to generate a URL param. 
 
-  This function is called after a URL change has been handled
-  by `router.handleURL`.
+  This function is used twice: once at the beginning
+  of a `transitionTo` to immediately attempt a URL
+  change
 
-  Takes an Array of `RecognizedHandler`s, and converts the raw
-  params hashes into deserialized objects by calling deserialize
-  on the handlers. This process builds up an Array of
-  `HandlerInfo`s. It then calls `setupContexts` with the Array.
-
-  If the `deserialize` method on a handler returns a promise
-  (i.e. has a method called `then`), this function will pause
-  building up the `HandlerInfo` Array until the promise is
-  resolved. It will use the resolved value as the context of
-  `HandlerInfo`.
 */
-function collectObjects(router, results, index, objects) {
-  if (results.length === index) {
-    var lastObject = objects[objects.length - 1],
-        lastHandler = lastObject && lastObject.handler;
+function urlForObjects(router, handlerInfos, objects, errorOnFailure) {
+  var lastHandlerName = handlerInfos[handlerInfos.length - 1].name,
+      params = router.paramsForHandler.apply(router, [lastHandlerName].concat(objects));
 
-    if (lastHandler && lastHandler.additionalHandler) {
-      var additionalResult = {
-        handler: lastHandler.additionalHandler(),
-        params: {},
-        isDynamic: false
-      };
-      results.push(additionalResult);
-    } else {
-      loaded(router);
-      setupContexts(router, objects);
-      return;
+  // Validate that the paramsForHandler did return invalid parameters, e.g.
+  // parameters with null/undefined values.
+  for (var key in params) {
+    if (!params.hasOwnProperty(key)) { continue; }
+
+    var value = params[key];
+    if (typeof value === "undefined" || value === null) {
+      if (errorOnFailure) {
+        throw new Error("Could not generate URL. Check that your serialize functions aren't populating the params hash with undefined/null values.");
+      } else {
+        return null;
+      }
     }
   }
-
-  var result = results[index];
-  var handler = router.getHandler(result.handler);
-  var object = handler.deserialize && handler.deserialize(result.params);
-
-  if (object && typeof object.then === 'function') {
-    loading(router);
-
-    // The chained `then` means that we can also catch errors that happen in `proceed`
-    object.then(proceed).then(null, function(error) {
-      failure(router, error);
-    });
-  } else {
-    proceed(object);
-  }
-
-  function proceed(value) {
-    if (handler.context !== object) {
-      setContext(handler, object);
-    }
-
-    var updatedObjects = objects.concat([{
-      context: value,
-      name: result.handler,
-      handler: router.getHandler(result.handler),
-      isDynamic: result.isDynamic
-    }]);
-    collectObjects(router, results, index + 1, updatedObjects);
-  }
+  return router.recognizer.generate(lastHandlerName, params);
 }
 
 /**
@@ -478,7 +625,9 @@ function setupContexts(router, handlerInfos) {
   eachHandler(partition.entered, function(handler, context) {
     if (aborted) { return; }
     if (handler.enter) { handler.enter(); }
+
     setContext(handler, context);
+
     if (handler.setup) {
       if (false === handler.setup(context)) {
         aborted = true;
@@ -486,6 +635,7 @@ function setupContexts(router, handlerInfos) {
     }
   });
 
+  // Perform post-transition client hook.
   if (router.didTransition) {
     router.didTransition(handlerInfos);
   }
@@ -608,4 +758,191 @@ function setContext(handler, context) {
   handler.context = context;
   if (handler.contextDidChange) { handler.contextDidChange(); }
 }
+
+/**
+  This is the transition event passed to transition handlers, used
+  for cancelling or redirecting an intended transition.
+*/
+function TransitionEvent(router, handlerInfos) {
+  this.router = router;
+  this.handlerInfos = handlerInfos;
+  this.currentIndex = 0;
+}
+
+/**
+  The `TransitionEvent` prototype contains all the public API
+  for transition event handlers declared in the `transitions`
+  hash of the handler. 
+ */
+TransitionEvent.prototype = {
+  /**
+    Halts the attempted transition and forwards arguments to
+    the router's `transitionTo`. Use this function to halt
+    and redirect a transition elsewhere.
+   */
+  transitionTo: function() {
+    this.preventTransition();
+    this.router.transitionTo.apply(this.router, arguments);
+  },
+
+  /**
+    Halts the attempted transition.
+   */
+  preventTransition: function() {
+    this.transitionCancelled = true;
+  },
+
+  /**
+    Returns the context object for this handler. 
+   */
+  getContext: function() {
+    if(this.isDestinationRoute) {
+      return this.handlerInfos[this.currentIndex].context();
+    } else {
+      throw new Error("getContext() can only be called from within destination routes.");
+    }
+  }
+};
+
+/**
+  @private
+
+  Executes all matching transition event handlers defined
+  in the `transitions` hash on the handlers. Halts the
+  algorithm and returns false if any one of the handlers
+  prevented or redirected the transition.
+
+  Order of handler execution is as follows:
+  1) Execute source handlers leaf to root
+  2) Execute destination handlers from leaf to root
+ */
+function runTransitionHandlers(router, destHandlerInfos) {
+  var transitionEvent = new TransitionEvent(router, destHandlerInfos),
+      sourceHandlerInfos = router.currentHandlerInfos, i;
+
+  // sourceHandlerInfos won't exist for very first transition.
+  if(sourceHandlerInfos) {
+    for (i = sourceHandlerInfos.length - 1; i >= 0; i--) {
+      if(!processTransitionRules(true, sourceHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+        return false;
+      }
+    }
+  }
+
+  if (transitionEvent.transitionCancelled) { return false; }
+  transitionEvent.isDestinationRoute = true;
+
+  for (i = 0; i < destHandlerInfos.length; i++) {
+    // Update the current context index on the transitionEvent
+    // so that getContext() will return the correct one. 
+    transitionEvent.currentIndex = i;
+    if(!processTransitionRules(false, destHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+  @private
+
+  Runs matching transition event handlers for a given `handlerInfo`.
+  Returns false if the transition was halted or redirected, else true.
+ */
+function processTransitionRules(checkingSourceRoutes, handlerInfo, sourceHandlerInfos, destHandlerInfos, transitionEvent) {
+  var handler = handlerInfo.handler, transitions = handler.transitions;
+  if(!transitions) { return true; }
+
+  for (var transitionRule in transitions) {
+    if (!transitions.hasOwnProperty(transitionRule)) { continue; }
+
+    var split = transitionRule.split(' '), fromTo = split[0], routeName = split[1], 
+        runHandler = null, handlerInfosToCheck = null;
+    
+    if (fromTo === 'to') {
+      if (checkingSourceRoutes) {
+        if (routeName === '*' && sourceHandlerInfos) {
+          runHandler = !checkHandlerMembership(handlerInfo.name, destHandlerInfos);
+        } else {
+          runHandler = checkHandlerMembership(routeName, destHandlerInfos);
+        }
+      }
+    } else if (fromTo === 'from') {
+      if (!checkingSourceRoutes) {
+        if (routeName === '*') {
+          runHandler = !checkHandlerMembership(handlerInfo.name, sourceHandlerInfos);
+        } else if (sourceHandlerInfos) {
+          runHandler = checkHandlerMembership(routeName, sourceHandlerInfos);
+        }
+      }
+    } else {
+      throw new Error("Badly formed transition handler key (expected 'to' or 'from'): " + transitionRule);
+    }
+
+    if (runHandler) {
+      var transitionHandler = transitions[transitionRule];
+      transitionHandler.call(handler, transitionEvent);
+
+      if(transitionEvent.transitionCancelled) { return false; }
+    }
+  }
+  return true;
+}
+
+function checkHandlerMembership(routeName, handlerInfos) {
+  for (var i = 0; i < handlerInfos.length; i += 1) {
+    if(handlerInfos[i].name === routeName) { return true; }
+  }
+  return false;
+}
+
+/**
+  @private
+
+  Returns a function that returns the context to use for
+  the provided `handler`. This is used for `handleURL`
+  transitions, and therefore makes use of the handler's
+  `deserialize` function to determine the context to use.
+ */
+function getHandleURLContextResolver(handler, params) {
+  var cachedContext;
+  return function() {
+    if(cachedContext) { return cachedContext; }
+    return cachedContext = handler.deserialize && handler.deserialize(params);
+  };
+}
+
+/**
+  @private
+
+  Returns a function that returns the context to use for
+  the provided `handler`. This is used for `transitionTo`
+  transitions.
+ */
+function getTransitionToContextResolver(isDynamic, index, startIndex, object, handler) {
+  var cachedContext;
+  return function() {
+    if(cachedContext) { return cachedContext; }
+
+    if (isDynamic) {
+      if(index < startIndex) {
+        object = handler.context;
+      }
+    } else {
+      // If we've passed the match point we need to deserialize again
+      // or if we never had a context
+      if (index > startIndex || !handler.hasOwnProperty('context')) {
+        if (handler.deserialize) {
+          object = handler.deserialize({});
+        }
+      // Otherwise use existing context
+      } else {
+        object = handler.context;
+      }
+    }
+    return cachedContext = object;
+  };
+}
+
 module.exports = Router;

--- a/dist/router.js
+++ b/dist/router.js
@@ -19,6 +19,122 @@
   */
 
 
+  function Transition(router, handlerInfos, updateURLMethod) {
+    this.router = router;
+    this.handlerInfos = handlerInfos;
+    this.updateURLMethod = updateURLMethod;
+    this.numPromises = 0;
+    this.resolvedContexts = [];
+  }
+
+  Transition.prototype = {
+  
+    /**
+      Perform the transition.
+    */
+    start: function() { this._step(0); },
+
+    /**
+      @private
+
+      This updates the URL for `transitionTo` once
+      the transition is complete and all context
+      promises (if any) have been resolved.
+    */
+    _updateURL: function() {
+      if (!this.finished || this.numPromises !== 0 || !this.updateURLMethod || this.updatedURL) { return; }
+      var url = urlForObjects(this.router, this.handlerInfos, this.resolvedContexts, true);
+      this.updateURLMethod.call(this.router, url);
+      this.updatedURL = true;
+    },
+
+    /**
+      @private
+
+      This function steps through the transition process,
+      pausing along the way if promise contexts are 
+      encounter (and a loading state is available).
+
+      Takes an array of functions that, when called, yield
+      a `HandlerInfo` that'll be used to build up the final
+      array of `HandlerInfo`s to be passed to `setupContexts`.
+
+      If the context provided in a `HandlerInfo` is a promise
+      (i.e. has a method called `then`), and a 'loading' 
+      handler has been provided, this function will pause
+      until the promise is resolved. Otherwise, the function
+      will proceed with the transition even if the context
+      is a promise.
+    */
+    _step: function(index) {
+      if(index === this.handlerInfos.length) {
+        exitLoadingState(this.router);
+        setupContexts(this.router, this.handlerInfos);
+
+        this.finished = true;
+        this._updateURL();
+        return;
+      }
+
+      var self = this,
+          handlerInfo = this.handlerInfos[index],
+          context = handlerInfo.context(),
+          resolvedContextsIndex = this.resolvedContexts.length;
+
+      if (context && typeof context.then === 'function') {
+        if (handlerInfo.isDynamic && this.updateURLMethod) {
+          // We'll still need to update the URL at the end of this
+          // transition, after all contexts have resolved.
+
+          // Reserve a spot for this context. It will be replaced later.
+          // A leafier route's context may resolve before a parent context, 
+          // so we have to be careful to preserve the ordering.
+          this.numPromises++;
+          this.resolvedContexts[resolvedContextsIndex] = context;
+          context.then(function(value) {
+            self.numPromises--;
+            self.resolvedContexts[resolvedContextsIndex] = value;
+            self._updateURL();
+          });
+        }
+
+        if (enterLoadingState(this.router, handlerInfo.name)) {
+          // We've entered the loading state associated with this route, so
+          // set up a promise so we can leave the loading state once it's resolved.
+          // The chained `then` means that we can also catch errors that happen in `proceed`
+          context.then(proceed).then(null, function(error) {
+            enterFailureState(self.router, error);
+          });
+        } else {
+          // No loading state associated with this route, so continue
+          // transitioning without waiting for promise to resolve.
+          proceed(context);
+        }
+      } else {
+        if (handlerInfo.isDynamic && this.updateURLMethod) {
+          this.resolvedContexts[resolvedContextsIndex] = context;
+        }
+        proceed(context);
+      }
+
+      function proceed(value) {
+        handlerInfo.context = value;
+
+        if (handlerInfo.isDynamic) { 
+          self.resolvedContexts[resolvedContextsIndex] = handlerInfo.context;
+        }
+
+        var handler = handlerInfo.handler;
+        if (handler.context !== handlerInfo.context) {
+          setContext(handler, handlerInfo.context);
+        }
+
+        self._step(index + 1);
+      }
+    }
+  };
+
+
   function Router() {
     this.recognizer = new RouteRecognizer();
   }
@@ -50,24 +166,60 @@
 
     /**
       The entry point for handling a change to the URL (usually
-      via the back and forward button).
-
-      Returns an Array of handlers and the parameters associated
-      with those parameters.
+      via the back and forward button). This will perform a transition
+      into the handlers that match the provided URL unless the 
+      transition is halted or redirected by a handler's
+      TransitionEvent handlers.
 
       @param {String} url a URL to process
-
-      @return {Array} an Array of `[handler, parameter]` tuples
     */
     handleURL: function(url) {
       var results = this.recognizer.recognize(url);
 
-      if (!results) {
+      // URL-less routes should also not be recognized.
+      if (!results || this.getHandler(results[results.length - 1].handler).notAccessibleByURL) {
         throw new Error("No route matched the URL '" + url + "'");
       }
 
-      collectObjects(this, results, 0, []);
+      var handlerInfos = [], router = this;
+      for (var i = 0; i < results.length; i += 1) {
+        var result = results[i], name = result.handler, handler = router.getHandler(name);
+
+        handlerInfos.push({ 
+          isDynamic: result.isDynamic, 
+          handler: handler, 
+          name: name, 
+          context: getHandleURLContextResolver(handler, result.params)
+        });
+      }
+
+      if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+      var transition = new Transition(this, handlerInfos);
+      transition.start();
     },
+
+
+    /**
+      Configure whether `updateURL`/`replaceURL` should be called
+      immediately at the beginning of `transitionTo` or whether
+      it should wait until all promises are resolved. 
+
+      The default behavior (null) is optimistic;
+      it will try to change the URL right away, but if a URL
+      can't be serialized, it'll wait until all promises are
+      resolved and try again later. 
+
+      When set to true (aggressive), the URL is changed immediately,
+      and if a URL can't be serialized, an Error will be raised.
+
+      When set to false, the URL will only be changed at the
+      very end of a `transitionTo`, after all promises have
+      resolved.
+
+      @param {String} url a URL to update to
+    */
+    updateURLImmediately: null,
 
     /**
       Hook point for updating the URL.
@@ -98,8 +250,10 @@
       @param {String} name the name of the route
     */
     transitionTo: function(name) {
-      var args = Array.prototype.slice.call(arguments, 1);
-      doTransition(this, name, this.updateURL, args);
+      var objects = Array.prototype.slice.call(arguments, 1),
+          transition = getDirectTransition(this, name, objects, this.updateURL);
+      if(!transition) { return; }
+      transition.start();
     },
 
     /**
@@ -111,8 +265,10 @@
       @param {String} name the name of the route
     */
     replaceWith: function(name) {
-      var args = Array.prototype.slice.call(arguments, 1);
-      doTransition(this, name, this.replaceURL, args);
+      var objects = Array.prototype.slice.call(arguments, 1),
+          transition = getDirectTransition(this, name, objects, this.replaceURL);
+      if(!transition) { return; }
+      transition.start();
     },
 
     /**
@@ -125,9 +281,50 @@
       @param {Array[Object]} contexts
       @return {Object} a serialized parameter hash
     */
-    paramsForHandler: function(handlerName, callback) {
-      var output = this._paramsForHandler(handlerName, [].slice.call(arguments, 1));
-      return output.params;
+    paramsForHandler: function(handlerName) {
+      var handlers = this.recognizer.handlersFor(handlerName),
+          objects = [].slice.call(arguments, 1),
+          params = {},
+          objectsToMatch = objects.length,
+          startIdx = handlers.length,
+          object, objectChanged, handlerObj, handler, names, i;
+
+      // Find out which handler to start matching at
+      for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+        if (handlers[i].names.length) {
+          objectsToMatch--;
+          startIdx = i;
+        }
+      }
+
+      if (objectsToMatch > 0) {
+        throw "More objects were passed than dynamic segments";
+      }
+
+      // Connect the objects to the routes
+      for (i=0; i<handlers.length; i++) {
+        handlerObj = handlers[i];
+        handler = this.getHandler(handlerObj.handler);
+        names = handlerObj.names;
+
+        // If it's a dynamic segment
+        if (handlerObj.names.length) {
+          // If we have objects, use them
+          if (i >= startIdx) {
+            object = objects.shift();
+          // Otherwise use existing context
+          } else {
+            object = handler.context;
+          }
+
+          // Serialize to generate params
+          if (handler.serialize) {
+            merge(params, handler.serialize(object, handlerObj.names));
+          }
+        } 
+      }
+
+      return params;
     },
 
     /**
@@ -143,98 +340,6 @@
     generate: function(handlerName) {
       var params = this.paramsForHandler.apply(this, arguments);
       return this.recognizer.generate(handlerName, params);
-    },
-
-    /**
-      @private
-
-      Used internally by `generate` and `transitionTo`.
-    */
-    _paramsForHandler: function(handlerName, objects, doUpdate) {
-      var handlers = this.recognizer.handlersFor(handlerName),
-          params = {},
-          toSetup = [],
-          startIdx = handlers.length,
-          objectsToMatch = objects.length,
-          object, objectChanged, handlerObj, handler, names, i;
-
-      // Find out which handler to start matching at
-      for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
-        if (handlers[i].names.length) {
-          objectsToMatch--;
-          startIdx = i;
-        }
-      }
-
-      if (objectsToMatch > 0) {
-        throw "More context objects were passed than there are dynamic segments for the route: "+handlerName;
-      }
-
-      // Connect the objects to the routes
-      for (i=0; i<handlers.length; i++) {
-        handlerObj = handlers[i];
-        handler = this.getHandler(handlerObj.handler);
-        names = handlerObj.names;
-        objectChanged = false;
-
-        // If it's a dynamic segment
-        if (names.length) {
-          // If we have objects, use them
-          if (i >= startIdx) {
-            object = objects.shift();
-            objectChanged = true;
-          // Otherwise use existing context
-          } else {
-            object = handler.context;
-          }
-
-          // Serialize to generate params
-          if (handler.serialize) {
-            merge(params, handler.serialize(object, names));
-          }
-        // If it's not a dynamic segment and we're updating
-        } else if (doUpdate) {
-          // If we've passed the match point we need to deserialize again
-          // or if we never had a context
-          if (i > startIdx || !handler.hasOwnProperty('context')) {
-            if (handler.deserialize) {
-              object = handler.deserialize({});
-              objectChanged = true;
-            }
-          // Otherwise use existing context
-          } else {
-            object = handler.context;
-          }
-        }
-
-        // Make sure that we update the context here so it's available to
-        // subsequent deserialize calls
-        if (doUpdate && objectChanged) {
-          // TODO: It's a bit awkward to set the context twice, see if we can DRY things up
-          setContext(handler, object);
-        }
-
-        toSetup.push({
-          isDynamic: !!handlerObj.names.length,
-          name: handlerObj.handler,
-          handler: handler,
-          context: object
-        });
-
-        if (i === handlers.length - 1) {
-          var lastHandler = toSetup[toSetup.length - 1],
-              additionalHandler;
-
-          if (additionalHandler = lastHandler.handler.additionalHandler) {
-            handlers.push({
-              handler: additionalHandler.call(lastHandler.handler),
-              names: []
-            });
-          }
-        }
-      }
-
-      return { params: params, toSetup: toSetup };
     },
 
     isActive: function(handlerName) {
@@ -279,25 +384,33 @@
   /**
     @private
 
-    This function is called the first time the `collectObjects`
-    function encounters a promise while converting URL parameters
-    into objects.
+    This function will resolve the `loading` handler, if one has
+    been specified, and trigger `enter` and `setup` on it if
+    the router has not already entered the loading state for 
+    this particular transition.
 
-    It triggers the `enter` and `setup` methods on the `loading`
-    handler.
+    Returns true if a `loading` handler exists, else false.
+    This return value is used to determine whether a transition
+    should pause when a promise context is encountered,
+    for both `transitionTo` and `handleURL` transitions.
+    If true (`loading` handler was found), the transition 
+    will pause for both transition types and only continue
+    once the promise has been resolved. If false, the 
+    transition will continue without pausing.
 
     @param {Router} router
+    @return {Boolean} true if loading state exists, else false
   */
-  function loading(router) {
+  function enterLoadingState(router) {
+    var handler = router.getHandler('loading');
+    if(!handler) { return false; }
+
     if (!router.isLoading) {
       router.isLoading = true;
-      var handler = router.getHandler('loading');
-
-      if (handler) {
-        if (handler.enter) { handler.enter(); }
-        if (handler.setup) { handler.setup(); }
-      }
+      if (handler.enter) { handler.enter(); }
+      if (handler.setup) { handler.setup(); }
     }
+    return true;
   }
 
   /**
@@ -306,11 +419,12 @@
     This function is called if a promise was previously
     encountered once all promises are resolved.
 
-    It triggers the `exit` method on the `loading` handler.
+    It triggers the `exit` method on the `loading` handler,
+    if one exists.
 
     @param {Router} router
   */
-  function loaded(router) {
+  function exitLoadingState(router) {
     router.isLoading = false;
     var handler = router.getHandler('loading');
     if (handler && handler.exit) { handler.exit(); }
@@ -322,9 +436,8 @@
     This function is called if any encountered promise
     is rejected.
 
-    It triggers the `exit` method on the `loading` handler,
-    the `enter` method on the `failure` handler, and the
-    `setup` method on the `failure` handler with the
+    It triggers the `exit` method on the `loading` handler
+    and the `setup` method on the `failure` handler with the
     `error`.
 
     @param {Router} router
@@ -332,89 +445,123 @@
       rejection, to pass into the failure handler's
       `setup` method.
   */
-  function failure(router, error) {
-    loaded(router);
+  function enterFailureState(router, error) {
+    exitLoadingState(router);
     var handler = router.getHandler('failure');
+    if (handler && handler.enter) { handler.enter(error); }
     if (handler && handler.setup) { handler.setup(error); }
   }
 
   /**
     @private
+
+    This function generates and returns a Transition object based 
+    on the handler name and context objects provided, or returns
+    null if the transition was halted or redirected.
+
+    @param {Router} router
+    @param {String} name The name of the target handler to
+      transition into.
+    @param {Array} objects the context objects to be passed
+      to handlers with dynamic parameters.
+    @param {Function} updateURLMethod `updateURL` or `replaceURL`,
+      the method used for changing the URL to reflect this transition.
   */
-  function doTransition(router, name, method, args) {
-    var output = router._paramsForHandler(name, args, true);
-    var params = output.params, toSetup = output.toSetup;
+  function getDirectTransition(router, name, objects, updateURLMethod) {
 
-    var url = router.recognizer.generate(name, params);
-    method.call(router, url);
+    var handlers = router.recognizer.handlersFor(name),
+        startIdx = handlers.length,
+        objectsToMatch = objects.length,
+        i, len;
 
-    setupContexts(router, toSetup);
+    // Find out which handler to start matching at
+    for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+      if (handlers[i].names.length) {
+        objectsToMatch--;
+        startIdx = i;
+      }
+    }
+
+    if (objectsToMatch > 0) {
+      throw "More objects were passed than dynamic segments";
+    }
+
+    var handlerInfos = [], objectIndex = 0;
+    for (i=0, len=handlers.length; i<len; i++) {
+      var handlerObj = handlers[i],
+          handlerName = handlerObj.handler,
+          handler = router.getHandler(handlerName),
+          isDynamic = !!handlerObj.names.length,
+          objectToUse = null;
+
+      if(isDynamic && i >= startIdx) {
+        objectToUse = objects[objectIndex++];
+      }
+
+      handlerInfos.push({ 
+        isDynamic: isDynamic, 
+        handler: handler, 
+        name: handlerName, 
+        context: getTransitionToContextResolver(isDynamic, i, startIdx, objectToUse, handler)
+      });
+    }
+
+    if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+    if (handlerInfos[handlerInfos.length - 1].handler.notAccessibleByURL) {
+      // This is a URL-less transition, so don't attempt to change the URL.
+      updateURLMethod = null;
+    }
+
+    if (updateURLMethod && router.updateURLImmediately !== false) {
+      // Attempt to generate the new URL immediately.
+      var url = urlForObjects(router, handlerInfos, objects, router.updateURLImmediately === true);
+      if(url) {
+        // Perform the URL change and prevent the Transition from doing it later.
+        updateURLMethod.call(router, url);
+        updateURLMethod = null;
+      }
+    }
+
+    return new Transition(router, handlerInfos, updateURLMethod);
   }
+
 
   /**
     @private
+ 
+    This function as called at the end of a 
+    `transitionTo` transition to perform the update to the 
+    URL. This function will fail and return false if 
+    a valid URL cannot be serialized by the context
+    objects provided, which can happen if `serialize`
+    is called with a promise which doesn't have enough
+    information on it to generate a URL param. 
 
-    This function is called after a URL change has been handled
-    by `router.handleURL`.
+    This function is used twice: once at the beginning
+    of a `transitionTo` to immediately attempt a URL
+    change
 
-    Takes an Array of `RecognizedHandler`s, and converts the raw
-    params hashes into deserialized objects by calling deserialize
-    on the handlers. This process builds up an Array of
-    `HandlerInfo`s. It then calls `setupContexts` with the Array.
-
-    If the `deserialize` method on a handler returns a promise
-    (i.e. has a method called `then`), this function will pause
-    building up the `HandlerInfo` Array until the promise is
-    resolved. It will use the resolved value as the context of
-    `HandlerInfo`.
   */
-  function collectObjects(router, results, index, objects) {
-    if (results.length === index) {
-      var lastObject = objects[objects.length - 1],
-          lastHandler = lastObject && lastObject.handler;
+  function urlForObjects(router, handlerInfos, objects, errorOnFailure) {
+    var lastHandlerName = handlerInfos[handlerInfos.length - 1].name,
+        params = router.paramsForHandler.apply(router, [lastHandlerName].concat(objects));
 
-      if (lastHandler && lastHandler.additionalHandler) {
-        var additionalResult = {
-          handler: lastHandler.additionalHandler(),
-          params: {},
-          isDynamic: false
-        };
-        results.push(additionalResult);
-      } else {
-        loaded(router);
-        setupContexts(router, objects);
-        return;
+    // Validate that the paramsForHandler did return invalid parameters, e.g.
+    // parameters with null/undefined values.
+    for (var key in params) {
+      if (!params.hasOwnProperty(key)) { continue; }
+
+      var value = params[key];
+      if (typeof value === "undefined" || value === null) {
+        if (errorOnFailure) {
+          throw new Error("Could not generate URL. Check that your serialize functions aren't populating the params hash with undefined/null values.");
+        } else {
+          return null;
+        }
       }
     }
-
-    var result = results[index];
-    var handler = router.getHandler(result.handler);
-    var object = handler.deserialize && handler.deserialize(result.params);
-
-    if (object && typeof object.then === 'function') {
-      loading(router);
-
-      // The chained `then` means that we can also catch errors that happen in `proceed`
-      object.then(proceed).then(null, function(error) {
-        failure(router, error);
-      });
-    } else {
-      proceed(object);
-    }
-
-    function proceed(value) {
-      if (handler.context !== object) {
-        setContext(handler, object);
-      }
-
-      var updatedObjects = objects.concat([{
-        context: value,
-        name: result.handler,
-        handler: router.getHandler(result.handler),
-        isDynamic: result.isDynamic
-      }]);
-      collectObjects(router, results, index + 1, updatedObjects);
-    }
+    return router.recognizer.generate(lastHandlerName, params);
   }
 
   /**
@@ -478,7 +625,9 @@
     eachHandler(partition.entered, function(handler, context) {
       if (aborted) { return; }
       if (handler.enter) { handler.enter(); }
+
       setContext(handler, context);
+
       if (handler.setup) {
         if (false === handler.setup(context)) {
           aborted = true;
@@ -486,6 +635,7 @@
       }
     });
 
+    // Perform post-transition client hook.
     if (router.didTransition) {
       router.didTransition(handlerInfos);
     }
@@ -608,5 +758,192 @@
     handler.context = context;
     if (handler.contextDidChange) { handler.contextDidChange(); }
   }
+
+  /**
+    This is the transition event passed to transition handlers, used
+    for cancelling or redirecting an intended transition.
+  */
+  function TransitionEvent(router, handlerInfos) {
+    this.router = router;
+    this.handlerInfos = handlerInfos;
+    this.currentIndex = 0;
+  }
+
+  /**
+    The `TransitionEvent` prototype contains all the public API
+    for transition event handlers declared in the `transitions`
+    hash of the handler. 
+   */
+  TransitionEvent.prototype = {
+    /**
+      Halts the attempted transition and forwards arguments to
+      the router's `transitionTo`. Use this function to halt
+      and redirect a transition elsewhere.
+     */
+    transitionTo: function() {
+      this.preventTransition();
+      this.router.transitionTo.apply(this.router, arguments);
+    },
+
+    /**
+      Halts the attempted transition.
+     */
+    preventTransition: function() {
+      this.transitionCancelled = true;
+    },
+
+    /**
+      Returns the context object for this handler. 
+     */
+    getContext: function() {
+      if(this.isDestinationRoute) {
+        return this.handlerInfos[this.currentIndex].context();
+      } else {
+        throw new Error("getContext() can only be called from within destination routes.");
+      }
+    }
+  };
+
+  /**
+    @private
+
+    Executes all matching transition event handlers defined
+    in the `transitions` hash on the handlers. Halts the
+    algorithm and returns false if any one of the handlers
+    prevented or redirected the transition.
+
+    Order of handler execution is as follows:
+    1) Execute source handlers leaf to root
+    2) Execute destination handlers from leaf to root
+   */
+  function runTransitionHandlers(router, destHandlerInfos) {
+    var transitionEvent = new TransitionEvent(router, destHandlerInfos),
+        sourceHandlerInfos = router.currentHandlerInfos, i;
+
+    // sourceHandlerInfos won't exist for very first transition.
+    if(sourceHandlerInfos) {
+      for (i = sourceHandlerInfos.length - 1; i >= 0; i--) {
+        if(!processTransitionRules(true, sourceHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+          return false;
+        }
+      }
+    }
+
+    if (transitionEvent.transitionCancelled) { return false; }
+    transitionEvent.isDestinationRoute = true;
+
+    for (i = 0; i < destHandlerInfos.length; i++) {
+      // Update the current context index on the transitionEvent
+      // so that getContext() will return the correct one. 
+      transitionEvent.currentIndex = i;
+      if(!processTransitionRules(false, destHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+    @private
+
+    Runs matching transition event handlers for a given `handlerInfo`.
+    Returns false if the transition was halted or redirected, else true.
+   */
+  function processTransitionRules(checkingSourceRoutes, handlerInfo, sourceHandlerInfos, destHandlerInfos, transitionEvent) {
+    var handler = handlerInfo.handler, transitions = handler.transitions;
+    if(!transitions) { return true; }
+
+    for (var transitionRule in transitions) {
+      if (!transitions.hasOwnProperty(transitionRule)) { continue; }
+
+      var split = transitionRule.split(' '), fromTo = split[0], routeName = split[1], 
+          runHandler = null, handlerInfosToCheck = null;
+    
+      if (fromTo === 'to') {
+        if (checkingSourceRoutes) {
+          if (routeName === '*' && sourceHandlerInfos) {
+            runHandler = !checkHandlerMembership(handlerInfo.name, destHandlerInfos);
+          } else {
+            runHandler = checkHandlerMembership(routeName, destHandlerInfos);
+          }
+        }
+      } else if (fromTo === 'from') {
+        if (!checkingSourceRoutes) {
+          if (routeName === '*') {
+            runHandler = !checkHandlerMembership(handlerInfo.name, sourceHandlerInfos);
+          } else if (sourceHandlerInfos) {
+            runHandler = checkHandlerMembership(routeName, sourceHandlerInfos);
+          }
+        }
+      } else {
+        throw new Error("Badly formed transition handler key (expected 'to' or 'from'): " + transitionRule);
+      }
+
+      if (runHandler) {
+        var transitionHandler = transitions[transitionRule];
+        transitionHandler.call(handler, transitionEvent);
+
+        if(transitionEvent.transitionCancelled) { return false; }
+      }
+    }
+    return true;
+  }
+
+  function checkHandlerMembership(routeName, handlerInfos) {
+    for (var i = 0; i < handlerInfos.length; i += 1) {
+      if(handlerInfos[i].name === routeName) { return true; }
+    }
+    return false;
+  }
+
+  /**
+    @private
+
+    Returns a function that returns the context to use for
+    the provided `handler`. This is used for `handleURL`
+    transitions, and therefore makes use of the handler's
+    `deserialize` function to determine the context to use.
+   */
+  function getHandleURLContextResolver(handler, params) {
+    var cachedContext;
+    return function() {
+      if(cachedContext) { return cachedContext; }
+      return cachedContext = handler.deserialize && handler.deserialize(params);
+    };
+  }
+
+  /**
+    @private
+
+    Returns a function that returns the context to use for
+    the provided `handler`. This is used for `transitionTo`
+    transitions.
+   */
+  function getTransitionToContextResolver(isDynamic, index, startIndex, object, handler) {
+    var cachedContext;
+    return function() {
+      if(cachedContext) { return cachedContext; }
+
+      if (isDynamic) {
+        if(index < startIndex) {
+          object = handler.context;
+        }
+      } else {
+        // If we've passed the match point we need to deserialize again
+        // or if we never had a context
+        if (index > startIndex || !handler.hasOwnProperty('context')) {
+          if (handler.deserialize) {
+            object = handler.deserialize({});
+          }
+        // Otherwise use existing context
+        } else {
+          object = handler.context;
+        }
+      }
+      return cachedContext = object;
+    };
+  }
+
   exports.Router = Router;
 })(window, window.RouteRecognizer);

--- a/lib/router.js
+++ b/lib/router.js
@@ -18,6 +18,122 @@
 
 import "route-recognizer" as RouteRecognizer;
 
+function Transition(router, handlerInfos, updateURLMethod) {
+  this.router = router;
+  this.handlerInfos = handlerInfos;
+  this.updateURLMethod = updateURLMethod;
+  this.numPromises = 0;
+  this.resolvedContexts = [];
+}
+
+Transition.prototype = {
+  
+  /**
+    Perform the transition.
+  */
+  start: function() { this._step(0); },
+
+  /**
+    @private
+
+    This updates the URL for `transitionTo` once
+    the transition is complete and all context
+    promises (if any) have been resolved.
+  */
+  _updateURL: function() {
+    if (!this.finished || this.numPromises !== 0 || !this.updateURLMethod || this.updatedURL) { return; }
+    var url = urlForObjects(this.router, this.handlerInfos, this.resolvedContexts, true);
+    this.updateURLMethod.call(this.router, url);
+    this.updatedURL = true;
+  },
+
+  /**
+    @private
+
+    This function steps through the transition process,
+    pausing along the way if promise contexts are 
+    encounter (and a loading state is available).
+
+    Takes an array of functions that, when called, yield
+    a `HandlerInfo` that'll be used to build up the final
+    array of `HandlerInfo`s to be passed to `setupContexts`.
+
+    If the context provided in a `HandlerInfo` is a promise
+    (i.e. has a method called `then`), and a 'loading' 
+    handler has been provided, this function will pause
+    until the promise is resolved. Otherwise, the function
+    will proceed with the transition even if the context
+    is a promise.
+  */
+  _step: function(index) {
+    if(index === this.handlerInfos.length) {
+      exitLoadingState(this.router);
+      setupContexts(this.router, this.handlerInfos);
+
+      this.finished = true;
+      this._updateURL();
+      return;
+    }
+
+    var self = this,
+        handlerInfo = this.handlerInfos[index],
+        context = handlerInfo.context(),
+        resolvedContextsIndex = this.resolvedContexts.length;
+
+    if (context && typeof context.then === 'function') {
+      if (handlerInfo.isDynamic && this.updateURLMethod) {
+        // We'll still need to update the URL at the end of this
+        // transition, after all contexts have resolved.
+
+        // Reserve a spot for this context. It will be replaced later.
+        // A leafier route's context may resolve before a parent context, 
+        // so we have to be careful to preserve the ordering.
+        this.numPromises++;
+        this.resolvedContexts[resolvedContextsIndex] = context;
+        context.then(function(value) {
+          self.numPromises--;
+          self.resolvedContexts[resolvedContextsIndex] = value;
+          self._updateURL();
+        });
+      }
+
+      if (enterLoadingState(this.router, handlerInfo.name)) {
+        // We've entered the loading state associated with this route, so
+        // set up a promise so we can leave the loading state once it's resolved.
+        // The chained `then` means that we can also catch errors that happen in `proceed`
+        context.then(proceed).then(null, function(error) {
+          enterFailureState(self.router, error);
+        });
+      } else {
+        // No loading state associated with this route, so continue
+        // transitioning without waiting for promise to resolve.
+        proceed(context);
+      }
+    } else {
+      if (handlerInfo.isDynamic && this.updateURLMethod) {
+        this.resolvedContexts[resolvedContextsIndex] = context;
+      }
+      proceed(context);
+    }
+
+    function proceed(value) {
+      handlerInfo.context = value;
+
+      if (handlerInfo.isDynamic) { 
+        self.resolvedContexts[resolvedContextsIndex] = handlerInfo.context;
+      }
+
+      var handler = handlerInfo.handler;
+      if (handler.context !== handlerInfo.context) {
+        setContext(handler, handlerInfo.context);
+      }
+
+      self._step(index + 1);
+    }
+  }
+};
+
+
 function Router() {
   this.recognizer = new RouteRecognizer();
 }
@@ -50,24 +166,60 @@ Router.prototype = {
 
   /**
     The entry point for handling a change to the URL (usually
-    via the back and forward button).
-
-    Returns an Array of handlers and the parameters associated
-    with those parameters.
+    via the back and forward button). This will perform a transition
+    into the handlers that match the provided URL unless the 
+    transition is halted or redirected by a handler's
+    TransitionEvent handlers.
 
     @param {String} url a URL to process
-
-    @return {Array} an Array of `[handler, parameter]` tuples
   */
   handleURL: function(url) {
     var results = this.recognizer.recognize(url);
 
-    if (!results) {
+    // URL-less routes should also not be recognized.
+    if (!results || this.getHandler(results[results.length - 1].handler).notAccessibleByURL) {
       throw new Error("No route matched the URL '" + url + "'");
     }
 
-    collectObjects(this, results, 0, []);
+    var handlerInfos = [], router = this;
+    for (var i = 0; i < results.length; i += 1) {
+      var result = results[i], name = result.handler, handler = router.getHandler(name);
+
+      handlerInfos.push({ 
+        isDynamic: result.isDynamic, 
+        handler: handler, 
+        name: name, 
+        context: getHandleURLContextResolver(handler, result.params)
+      });
+    }
+
+    if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+    var transition = new Transition(this, handlerInfos);
+    transition.start();
   },
+
+
+  /**
+    Configure whether `updateURL`/`replaceURL` should be called
+    immediately at the beginning of `transitionTo` or whether
+    it should wait until all promises are resolved. 
+
+    The default behavior (null) is optimistic;
+    it will try to change the URL right away, but if a URL
+    can't be serialized, it'll wait until all promises are
+    resolved and try again later. 
+
+    When set to true (aggressive), the URL is changed immediately,
+    and if a URL can't be serialized, an Error will be raised.
+
+    When set to false, the URL will only be changed at the
+    very end of a `transitionTo`, after all promises have
+    resolved.
+
+    @param {String} url a URL to update to
+  */
+  updateURLImmediately: null,
 
   /**
     Hook point for updating the URL.
@@ -98,8 +250,10 @@ Router.prototype = {
     @param {String} name the name of the route
   */
   transitionTo: function(name) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    doTransition(this, name, this.updateURL, args);
+    var objects = Array.prototype.slice.call(arguments, 1),
+        transition = getDirectTransition(this, name, objects, this.updateURL);
+    if(!transition) { return; }
+    transition.start();
   },
 
   /**
@@ -111,8 +265,10 @@ Router.prototype = {
     @param {String} name the name of the route
   */
   replaceWith: function(name) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    doTransition(this, name, this.replaceURL, args);
+    var objects = Array.prototype.slice.call(arguments, 1),
+        transition = getDirectTransition(this, name, objects, this.replaceURL);
+    if(!transition) { return; }
+    transition.start();
   },
 
   /**
@@ -125,9 +281,50 @@ Router.prototype = {
     @param {Array[Object]} contexts
     @return {Object} a serialized parameter hash
   */
-  paramsForHandler: function(handlerName, callback) {
-    var output = this._paramsForHandler(handlerName, [].slice.call(arguments, 1));
-    return output.params;
+  paramsForHandler: function(handlerName) {
+    var handlers = this.recognizer.handlersFor(handlerName),
+        objects = [].slice.call(arguments, 1),
+        params = {},
+        objectsToMatch = objects.length,
+        startIdx = handlers.length,
+        object, objectChanged, handlerObj, handler, names, i;
+
+    // Find out which handler to start matching at
+    for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+      if (handlers[i].names.length) {
+        objectsToMatch--;
+        startIdx = i;
+      }
+    }
+
+    if (objectsToMatch > 0) {
+      throw "More objects were passed than dynamic segments";
+    }
+
+    // Connect the objects to the routes
+    for (i=0; i<handlers.length; i++) {
+      handlerObj = handlers[i];
+      handler = this.getHandler(handlerObj.handler);
+      names = handlerObj.names;
+
+      // If it's a dynamic segment
+      if (handlerObj.names.length) {
+        // If we have objects, use them
+        if (i >= startIdx) {
+          object = objects.shift();
+        // Otherwise use existing context
+        } else {
+          object = handler.context;
+        }
+
+        // Serialize to generate params
+        if (handler.serialize) {
+          merge(params, handler.serialize(object, handlerObj.names));
+        }
+      } 
+    }
+
+    return params;
   },
 
   /**
@@ -143,98 +340,6 @@ Router.prototype = {
   generate: function(handlerName) {
     var params = this.paramsForHandler.apply(this, arguments);
     return this.recognizer.generate(handlerName, params);
-  },
-
-  /**
-    @private
-
-    Used internally by `generate` and `transitionTo`.
-  */
-  _paramsForHandler: function(handlerName, objects, doUpdate) {
-    var handlers = this.recognizer.handlersFor(handlerName),
-        params = {},
-        toSetup = [],
-        startIdx = handlers.length,
-        objectsToMatch = objects.length,
-        object, objectChanged, handlerObj, handler, names, i;
-
-    // Find out which handler to start matching at
-    for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
-      if (handlers[i].names.length) {
-        objectsToMatch--;
-        startIdx = i;
-      }
-    }
-
-    if (objectsToMatch > 0) {
-      throw "More context objects were passed than there are dynamic segments for the route: "+handlerName;
-    }
-
-    // Connect the objects to the routes
-    for (i=0; i<handlers.length; i++) {
-      handlerObj = handlers[i];
-      handler = this.getHandler(handlerObj.handler);
-      names = handlerObj.names;
-      objectChanged = false;
-
-      // If it's a dynamic segment
-      if (names.length) {
-        // If we have objects, use them
-        if (i >= startIdx) {
-          object = objects.shift();
-          objectChanged = true;
-        // Otherwise use existing context
-        } else {
-          object = handler.context;
-        }
-
-        // Serialize to generate params
-        if (handler.serialize) {
-          merge(params, handler.serialize(object, names));
-        }
-      // If it's not a dynamic segment and we're updating
-      } else if (doUpdate) {
-        // If we've passed the match point we need to deserialize again
-        // or if we never had a context
-        if (i > startIdx || !handler.hasOwnProperty('context')) {
-          if (handler.deserialize) {
-            object = handler.deserialize({});
-            objectChanged = true;
-          }
-        // Otherwise use existing context
-        } else {
-          object = handler.context;
-        }
-      }
-
-      // Make sure that we update the context here so it's available to
-      // subsequent deserialize calls
-      if (doUpdate && objectChanged) {
-        // TODO: It's a bit awkward to set the context twice, see if we can DRY things up
-        setContext(handler, object);
-      }
-
-      toSetup.push({
-        isDynamic: !!handlerObj.names.length,
-        name: handlerObj.handler,
-        handler: handler,
-        context: object
-      });
-
-      if (i === handlers.length - 1) {
-        var lastHandler = toSetup[toSetup.length - 1],
-            additionalHandler;
-
-        if (additionalHandler = lastHandler.handler.additionalHandler) {
-          handlers.push({
-            handler: additionalHandler.call(lastHandler.handler),
-            names: []
-          });
-        }
-      }
-    }
-
-    return { params: params, toSetup: toSetup };
   },
 
   isActive: function(handlerName) {
@@ -279,25 +384,33 @@ function isCurrent(currentHandlerInfos, handlerName) {
 /**
   @private
 
-  This function is called the first time the `collectObjects`
-  function encounters a promise while converting URL parameters
-  into objects.
+  This function will resolve the `loading` handler, if one has
+  been specified, and trigger `enter` and `setup` on it if
+  the router has not already entered the loading state for 
+  this particular transition.
 
-  It triggers the `enter` and `setup` methods on the `loading`
-  handler.
+  Returns true if a `loading` handler exists, else false.
+  This return value is used to determine whether a transition
+  should pause when a promise context is encountered,
+  for both `transitionTo` and `handleURL` transitions.
+  If true (`loading` handler was found), the transition 
+  will pause for both transition types and only continue
+  once the promise has been resolved. If false, the 
+  transition will continue without pausing.
 
   @param {Router} router
+  @return {Boolean} true if loading state exists, else false
 */
-function loading(router) {
+function enterLoadingState(router) {
+  var handler = router.getHandler('loading');
+  if(!handler) { return false; }
+
   if (!router.isLoading) {
     router.isLoading = true;
-    var handler = router.getHandler('loading');
-
-    if (handler) {
-      if (handler.enter) { handler.enter(); }
-      if (handler.setup) { handler.setup(); }
-    }
+    if (handler.enter) { handler.enter(); }
+    if (handler.setup) { handler.setup(); }
   }
+  return true;
 }
 
 /**
@@ -306,11 +419,12 @@ function loading(router) {
   This function is called if a promise was previously
   encountered once all promises are resolved.
 
-  It triggers the `exit` method on the `loading` handler.
+  It triggers the `exit` method on the `loading` handler,
+  if one exists.
 
   @param {Router} router
 */
-function loaded(router) {
+function exitLoadingState(router) {
   router.isLoading = false;
   var handler = router.getHandler('loading');
   if (handler && handler.exit) { handler.exit(); }
@@ -322,9 +436,8 @@ function loaded(router) {
   This function is called if any encountered promise
   is rejected.
 
-  It triggers the `exit` method on the `loading` handler,
-  the `enter` method on the `failure` handler, and the
-  `setup` method on the `failure` handler with the
+  It triggers the `exit` method on the `loading` handler
+  and the `setup` method on the `failure` handler with the
   `error`.
 
   @param {Router} router
@@ -332,89 +445,123 @@ function loaded(router) {
     rejection, to pass into the failure handler's
     `setup` method.
 */
-function failure(router, error) {
-  loaded(router);
+function enterFailureState(router, error) {
+  exitLoadingState(router);
   var handler = router.getHandler('failure');
+  if (handler && handler.enter) { handler.enter(error); }
   if (handler && handler.setup) { handler.setup(error); }
 }
 
 /**
   @private
+
+  This function generates and returns a Transition object based 
+  on the handler name and context objects provided, or returns
+  null if the transition was halted or redirected.
+
+  @param {Router} router
+  @param {String} name The name of the target handler to
+    transition into.
+  @param {Array} objects the context objects to be passed
+    to handlers with dynamic parameters.
+  @param {Function} updateURLMethod `updateURL` or `replaceURL`,
+    the method used for changing the URL to reflect this transition.
 */
-function doTransition(router, name, method, args) {
-  var output = router._paramsForHandler(name, args, true);
-  var params = output.params, toSetup = output.toSetup;
+function getDirectTransition(router, name, objects, updateURLMethod) {
 
-  var url = router.recognizer.generate(name, params);
-  method.call(router, url);
+  var handlers = router.recognizer.handlersFor(name),
+      startIdx = handlers.length,
+      objectsToMatch = objects.length,
+      i, len;
 
-  setupContexts(router, toSetup);
+  // Find out which handler to start matching at
+  for (i=handlers.length-1; i>=0 && objectsToMatch>0; i--) {
+    if (handlers[i].names.length) {
+      objectsToMatch--;
+      startIdx = i;
+    }
+  }
+
+  if (objectsToMatch > 0) {
+    throw "More objects were passed than dynamic segments";
+  }
+
+  var handlerInfos = [], objectIndex = 0;
+  for (i=0, len=handlers.length; i<len; i++) {
+    var handlerObj = handlers[i],
+        handlerName = handlerObj.handler,
+        handler = router.getHandler(handlerName),
+        isDynamic = !!handlerObj.names.length,
+        objectToUse = null;
+
+    if(isDynamic && i >= startIdx) {
+      objectToUse = objects[objectIndex++];
+    }
+
+    handlerInfos.push({ 
+      isDynamic: isDynamic, 
+      handler: handler, 
+      name: handlerName, 
+      context: getTransitionToContextResolver(isDynamic, i, startIdx, objectToUse, handler)
+    });
+  }
+
+  if (!runTransitionHandlers(router, handlerInfos)) { return; }
+
+  if (handlerInfos[handlerInfos.length - 1].handler.notAccessibleByURL) {
+    // This is a URL-less transition, so don't attempt to change the URL.
+    updateURLMethod = null;
+  }
+
+  if (updateURLMethod && router.updateURLImmediately !== false) {
+    // Attempt to generate the new URL immediately.
+    var url = urlForObjects(router, handlerInfos, objects, router.updateURLImmediately === true);
+    if(url) {
+      // Perform the URL change and prevent the Transition from doing it later.
+      updateURLMethod.call(router, url);
+      updateURLMethod = null;
+    }
+  }
+
+  return new Transition(router, handlerInfos, updateURLMethod);
 }
+
 
 /**
   @private
+ 
+  This function as called at the end of a 
+  `transitionTo` transition to perform the update to the 
+  URL. This function will fail and return false if 
+  a valid URL cannot be serialized by the context
+  objects provided, which can happen if `serialize`
+  is called with a promise which doesn't have enough
+  information on it to generate a URL param. 
 
-  This function is called after a URL change has been handled
-  by `router.handleURL`.
+  This function is used twice: once at the beginning
+  of a `transitionTo` to immediately attempt a URL
+  change
 
-  Takes an Array of `RecognizedHandler`s, and converts the raw
-  params hashes into deserialized objects by calling deserialize
-  on the handlers. This process builds up an Array of
-  `HandlerInfo`s. It then calls `setupContexts` with the Array.
-
-  If the `deserialize` method on a handler returns a promise
-  (i.e. has a method called `then`), this function will pause
-  building up the `HandlerInfo` Array until the promise is
-  resolved. It will use the resolved value as the context of
-  `HandlerInfo`.
 */
-function collectObjects(router, results, index, objects) {
-  if (results.length === index) {
-    var lastObject = objects[objects.length - 1],
-        lastHandler = lastObject && lastObject.handler;
+function urlForObjects(router, handlerInfos, objects, errorOnFailure) {
+  var lastHandlerName = handlerInfos[handlerInfos.length - 1].name,
+      params = router.paramsForHandler.apply(router, [lastHandlerName].concat(objects));
 
-    if (lastHandler && lastHandler.additionalHandler) {
-      var additionalResult = {
-        handler: lastHandler.additionalHandler(),
-        params: {},
-        isDynamic: false
-      };
-      results.push(additionalResult);
-    } else {
-      loaded(router);
-      setupContexts(router, objects);
-      return;
+  // Validate that the paramsForHandler did return invalid parameters, e.g.
+  // parameters with null/undefined values.
+  for (var key in params) {
+    if (!params.hasOwnProperty(key)) { continue; }
+
+    var value = params[key];
+    if (typeof value === "undefined" || value === null) {
+      if (errorOnFailure) {
+        throw new Error("Could not generate URL. Check that your serialize functions aren't populating the params hash with undefined/null values.");
+      } else {
+        return null;
+      }
     }
   }
-
-  var result = results[index];
-  var handler = router.getHandler(result.handler);
-  var object = handler.deserialize && handler.deserialize(result.params);
-
-  if (object && typeof object.then === 'function') {
-    loading(router);
-
-    // The chained `then` means that we can also catch errors that happen in `proceed`
-    object.then(proceed).then(null, function(error) {
-      failure(router, error);
-    });
-  } else {
-    proceed(object);
-  }
-
-  function proceed(value) {
-    if (handler.context !== object) {
-      setContext(handler, object);
-    }
-
-    var updatedObjects = objects.concat([{
-      context: value,
-      name: result.handler,
-      handler: router.getHandler(result.handler),
-      isDynamic: result.isDynamic
-    }]);
-    collectObjects(router, results, index + 1, updatedObjects);
-  }
+  return router.recognizer.generate(lastHandlerName, params);
 }
 
 /**
@@ -478,7 +625,9 @@ function setupContexts(router, handlerInfos) {
   eachHandler(partition.entered, function(handler, context) {
     if (aborted) { return; }
     if (handler.enter) { handler.enter(); }
+
     setContext(handler, context);
+
     if (handler.setup) {
       if (false === handler.setup(context)) {
         aborted = true;
@@ -486,6 +635,7 @@ function setupContexts(router, handlerInfos) {
     }
   });
 
+  // Perform post-transition client hook.
   if (router.didTransition) {
     router.didTransition(handlerInfos);
   }
@@ -608,3 +758,190 @@ function setContext(handler, context) {
   handler.context = context;
   if (handler.contextDidChange) { handler.contextDidChange(); }
 }
+
+/**
+  This is the transition event passed to transition handlers, used
+  for cancelling or redirecting an intended transition.
+*/
+function TransitionEvent(router, handlerInfos) {
+  this.router = router;
+  this.handlerInfos = handlerInfos;
+  this.currentIndex = 0;
+}
+
+/**
+  The `TransitionEvent` prototype contains all the public API
+  for transition event handlers declared in the `transitions`
+  hash of the handler. 
+ */
+TransitionEvent.prototype = {
+  /**
+    Halts the attempted transition and forwards arguments to
+    the router's `transitionTo`. Use this function to halt
+    and redirect a transition elsewhere.
+   */
+  transitionTo: function() {
+    this.preventTransition();
+    this.router.transitionTo.apply(this.router, arguments);
+  },
+
+  /**
+    Halts the attempted transition.
+   */
+  preventTransition: function() {
+    this.transitionCancelled = true;
+  },
+
+  /**
+    Returns the context object for this handler. 
+   */
+  getContext: function() {
+    if(this.isDestinationRoute) {
+      return this.handlerInfos[this.currentIndex].context();
+    } else {
+      throw new Error("getContext() can only be called from within destination routes.");
+    }
+  }
+};
+
+/**
+  @private
+
+  Executes all matching transition event handlers defined
+  in the `transitions` hash on the handlers. Halts the
+  algorithm and returns false if any one of the handlers
+  prevented or redirected the transition.
+
+  Order of handler execution is as follows:
+  1) Execute source handlers leaf to root
+  2) Execute destination handlers from leaf to root
+ */
+function runTransitionHandlers(router, destHandlerInfos) {
+  var transitionEvent = new TransitionEvent(router, destHandlerInfos),
+      sourceHandlerInfos = router.currentHandlerInfos, i;
+
+  // sourceHandlerInfos won't exist for very first transition.
+  if(sourceHandlerInfos) {
+    for (i = sourceHandlerInfos.length - 1; i >= 0; i--) {
+      if(!processTransitionRules(true, sourceHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+        return false;
+      }
+    }
+  }
+
+  if (transitionEvent.transitionCancelled) { return false; }
+  transitionEvent.isDestinationRoute = true;
+
+  for (i = 0; i < destHandlerInfos.length; i++) {
+    // Update the current context index on the transitionEvent
+    // so that getContext() will return the correct one. 
+    transitionEvent.currentIndex = i;
+    if(!processTransitionRules(false, destHandlerInfos[i], sourceHandlerInfos, destHandlerInfos, transitionEvent)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+  @private
+
+  Runs matching transition event handlers for a given `handlerInfo`.
+  Returns false if the transition was halted or redirected, else true.
+ */
+function processTransitionRules(checkingSourceRoutes, handlerInfo, sourceHandlerInfos, destHandlerInfos, transitionEvent) {
+  var handler = handlerInfo.handler, transitions = handler.transitions;
+  if(!transitions) { return true; }
+
+  for (var transitionRule in transitions) {
+    if (!transitions.hasOwnProperty(transitionRule)) { continue; }
+
+    var split = transitionRule.split(' '), fromTo = split[0], routeName = split[1], 
+        runHandler = null, handlerInfosToCheck = null;
+    
+    if (fromTo === 'to') {
+      if (checkingSourceRoutes) {
+        if (routeName === '*' && sourceHandlerInfos) {
+          runHandler = !checkHandlerMembership(handlerInfo.name, destHandlerInfos);
+        } else {
+          runHandler = checkHandlerMembership(routeName, destHandlerInfos);
+        }
+      }
+    } else if (fromTo === 'from') {
+      if (!checkingSourceRoutes) {
+        if (routeName === '*') {
+          runHandler = !checkHandlerMembership(handlerInfo.name, sourceHandlerInfos);
+        } else if (sourceHandlerInfos) {
+          runHandler = checkHandlerMembership(routeName, sourceHandlerInfos);
+        }
+      }
+    } else {
+      throw new Error("Badly formed transition handler key (expected 'to' or 'from'): " + transitionRule);
+    }
+
+    if (runHandler) {
+      var transitionHandler = transitions[transitionRule];
+      transitionHandler.call(handler, transitionEvent);
+
+      if(transitionEvent.transitionCancelled) { return false; }
+    }
+  }
+  return true;
+}
+
+function checkHandlerMembership(routeName, handlerInfos) {
+  for (var i = 0; i < handlerInfos.length; i += 1) {
+    if(handlerInfos[i].name === routeName) { return true; }
+  }
+  return false;
+}
+
+/**
+  @private
+
+  Returns a function that returns the context to use for
+  the provided `handler`. This is used for `handleURL`
+  transitions, and therefore makes use of the handler's
+  `deserialize` function to determine the context to use.
+ */
+function getHandleURLContextResolver(handler, params) {
+  var cachedContext;
+  return function() {
+    if(cachedContext) { return cachedContext; }
+    return cachedContext = handler.deserialize && handler.deserialize(params);
+  };
+}
+
+/**
+  @private
+
+  Returns a function that returns the context to use for
+  the provided `handler`. This is used for `transitionTo`
+  transitions.
+ */
+function getTransitionToContextResolver(isDynamic, index, startIndex, object, handler) {
+  var cachedContext;
+  return function() {
+    if(cachedContext) { return cachedContext; }
+
+    if (isDynamic) {
+      if(index < startIndex) {
+        object = handler.context;
+      }
+    } else {
+      // If we've passed the match point we need to deserialize again
+      // or if we never had a context
+      if (index > startIndex || !handler.hasOwnProperty('context')) {
+        if (handler.deserialize) {
+          object = handler.deserialize({});
+        }
+      // Otherwise use existing context
+      } else {
+        object = handler.context;
+      }
+    }
+    return cachedContext = object;
+  };
+}
+


### PR DESCRIPTION
This rewrite was originally only intended to solve the first feature 
described below (unified `handleURL` and `transitionTo` behavior), which
called for a major restructuring of the code to allow for both
`transitionTo` and `handleURL` transitions to be pausable when promise
contexts were encountered. 75% of this rather major code change is
restructuring to solve this first problem, but I've foraged on ahead
to take a stab at some other major issues that many have been
complaining about. I recognize this is a major PR to keep in one's
brain, and if you'd like me to split things out, I can do it, but 
I figured I'd at least give everyone a chance to weigh in on the
proposed changes and understand everything that's wacky or missing
from the new router. Without further ado:
## `handleURL` and `transitionTo` behavior is unified

Previously, only
`handleURL` would cause the router to go into a loading state when a
promise was encountered. Now the logic is as follows:
For both `transitionTo` and `handleURL`, if a promise context is
provided to a route, check and see if a global loading state exists
(as before). If so, pause the transition until promise resolves and
enter the loading state in the meantime, else continue with the
transition under the assumption that leafier routes can handle the
unresolved promise. At some point in the future, we should reconsider
per-route loading states like router v1.
## Preventable/redirectable transitions

Please see API described at https://gist.github.com/machty/5170781
## URL-less routes

Setting notAccessibleByURL to true on a handler will
make it inaccessible to URL changes, and will prevent a URL update
from happening at the end of a transitionTo
## Promise-based URL-changing

Previously, transitionTo would immediately
try to serialize transitioned-to route to determine the new URL, but
if the context is a simple promise object (not an Ember Data Deferred
with knowledge of its `id` property), the serialize can't succeed
until the promise has been resolved. @wycats suggested that the update
shouldn't happen until promises are resolved, but then again, often
enough data is available to serialize even if the promise isn't
resolved, and it would be undesirable to have transitionTo'd into a
route and unnecessarily be waiting for the URL to show up. 

So this PR
takes an eager but configurable approach to this problem. By default,
the serialization attempt happens immediately. If one of the params
set by a router's `serialize` method has a null/undefined value, the
serialize is considered a failure, and the URL change won't be
attempted until after all promises have resolved. This behavior is
also configurable via the `updateURLImmediately` property on the
router. If set to true, if the serialization fails, an error is raised
while retrying later. If set to false, the first serialization attempt
is never made, and is only attempted at the end of the transition
after all promises have resolved. Closes #9.
