### PR TITLE
Avoid updating contexts on route change unless necessary

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -156,6 +156,7 @@ Router.prototype = {
         toSetup = [],
         startIdx = handlers.length,
         objectsToMatch = objects.length,
+        parentObjectChanged = false,
         object, objectChanged, handlerObj, handler, names, i;
 
     // Find out which handler to start matching at
@@ -182,7 +183,9 @@ Router.prototype = {
         // If we have objects, use them
         if (i >= startIdx) {
           object = objects.shift();
-          objectChanged = true;
+          if (object !== handler.context) {
+            objectChanged = true;
+          }
         // Otherwise use existing context
         } else {
           object = handler.context;
@@ -194,9 +197,10 @@ Router.prototype = {
         }
       // If it's not a dynamic segment and we're updating
       } else if (doUpdate) {
-        // If we've passed the match point we need to deserialize again
-        // or if we never had a context
-        if (i > startIdx || !handler.hasOwnProperty('context')) {
+        // If we've passed the match point we need to deserialize again,
+        // only if any preceeding objects have changed, or if we never
+        // had a context
+        if ((i > startIdx && parentObjectChanged) || !handler.hasOwnProperty('context')) {
           if (handler.deserialize) {
             object = handler.deserialize({});
             objectChanged = true;
@@ -210,6 +214,7 @@ Router.prototype = {
       // Make sure that we update the context here so it's available to
       // subsequent deserialize calls
       if (doUpdate && objectChanged) {
+        parentObjectChanged = true
         // TODO: It's a bit awkward to set the context twice, see if we can DRY things up
         setContext(handler, object);
       }


### PR DESCRIPTION
On route change, contexts for dynamic segments are always marked updated,
even when identical. Additionally, any segment after the first dynamic
segment is forced to deserialize, even if the dynamic segments have not
changed.

This change tracks whether any preceeding segments have changed before 
updating contexts, and avoids unnecessary reloads/redraws.

I mistakenly submitted this against the vendored version in Ember first, because I wasn't familiar with the project structure, so some of you may have seen this before.

I'm afraid I'm having trouble coming up with tests for this (I tried from a few different angles), because the current behaviour doesn't appear to be tested.  It should be pretty obvious what this is trying to achieve, and for routes with multiple or deeply nested dynamic segments, triggering a reload of every segment after the first dynamic segment is really harsh, so I'd love to get this merged, but I need a little help.
