### PR TITLE
URL invalid change can transition to error handler

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -65,7 +65,12 @@ define("router",
         var results = this.recognizer.recognize(url);
 
         if (!results) {
-          throw new Error("No route matched the URL '" + url + "'");
+          var handler = this.getHandler('error');
+          if (handler)  {
+            results = [{handler: 'error', params: {}, isDynamic: false}];
+          } else {
+            throw new Error("No route matched the URL '" + url + "'");
+          }
         }
 
         collectObjects(this, results, 0, []);

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -63,7 +63,12 @@ Router.prototype = {
     var results = this.recognizer.recognize(url);
 
     if (!results) {
-      throw new Error("No route matched the URL '" + url + "'");
+      var handler = this.getHandler('error');
+      if (handler)  {
+        results = [{handler: 'error', params: {}, isDynamic: false}];
+      } else {
+        throw new Error("No route matched the URL '" + url + "'");
+      }
     }
 
     collectObjects(this, results, 0, []);

--- a/dist/router.js
+++ b/dist/router.js
@@ -63,7 +63,12 @@
       var results = this.recognizer.recognize(url);
 
       if (!results) {
-        throw new Error("No route matched the URL '" + url + "'");
+        var handler = this.getHandler('error');
+        if (handler)  {
+          results = [{handler: 'error', params: {}, isDynamic: false}];
+        } else {
+          throw new Error("No route matched the URL '" + url + "'");
+        }
       }
 
       collectObjects(this, results, 0, []);

--- a/lib/router.js
+++ b/lib/router.js
@@ -63,7 +63,12 @@ Router.prototype = {
     var results = this.recognizer.recognize(url);
 
     if (!results) {
-      throw new Error("No route matched the URL '" + url + "'");
+      var handler = this.getHandler('error');
+      if (handler)  {
+        results = [{handler: 'error', params: {}, isDynamic: false}];
+      } else {
+        throw new Error("No route matched the URL '" + url + "'");
+      }
     }
 
     collectObjects(this, results, 0, []);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -41,10 +41,60 @@ test("Mapping adds named routes to the end", function() {
   equal(url, "/posts");
 });
 
-test("Handling an invalid URL raises an exception", function() {
+test("Handling an invalid URL without error handler raises an exception ", function() {
+  handlers = {};
   throws(function() {
     router.handleURL("/unknown");
   }, /no route matched/i);
+});
+
+asyncTest("Handling an invalid URL with an error handler, it enters the error state", function() {
+
+  expect(1);
+
+  var errorHandler = {
+    setup: function() {
+      ok(true, "error was called");
+      start();
+    }
+  }
+
+  handlers = {error: errorHandler};
+
+  router.handleURL("/unknown");
+});
+
+asyncTest("When transitioned via URL change to an unknow route, triggers exit callbacks on the current route", function() {
+  expect(3);
+
+  var indexHandler = {
+
+    enter: function() {
+
+      ok(true, "The index handler was entered only once");
+      setTimeout(function() {
+        router.handleURL("/unknown");
+      }, 0);
+    },
+
+    exit: function() {
+      ok(true, "The index handler was exited");
+    }
+  };
+
+  var errorHandler = {
+    setup: function() {
+      ok(true, "error was entered");
+      start();
+    }
+  }
+
+  handlers = {
+    index: indexHandler,
+    error: errorHandler
+  };
+
+  router.handleURL("/index");
 });
 
 function routePath(infos) {


### PR DESCRIPTION
An Invalid URL is a common case on web applications. This is a simple implementation to enter an `error` state when its handler is available. Otherwise, it threw an exception.
