### PR TITLE
Added bubbling events via `return true`

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -605,17 +605,24 @@ define("router",
         throw new Error("Could not trigger event '" + name + "'. There are no active handlers");
       }
 
+      var eventWasHandled = false;
+
       for (var i=currentHandlerInfos.length-1; i>=0; i--) {
         var handlerInfo = currentHandlerInfos[i],
             handler = handlerInfo.handler;
 
         if (handler.events && handler.events[name]) {
-          handler.events[name].apply(handler, args);
-          return;
+          if (handler.events[name].apply(handler, args) === true) {
+            eventWasHandled = true;
+          } else {
+            return;
+          }
         }
       }
 
-      throw new Error("Nothing handled the event '" + name + "'.");
+      if (!eventWasHandled) {
+        throw new Error("Nothing handled the event '" + name + "'.");
+      }
     }
 
     function setContext(handler, context) {

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -603,17 +603,24 @@ function trigger(router, args) {
     throw new Error("Could not trigger event '" + name + "'. There are no active handlers");
   }
 
+  var eventWasHandled = false;
+
   for (var i=currentHandlerInfos.length-1; i>=0; i--) {
     var handlerInfo = currentHandlerInfos[i],
         handler = handlerInfo.handler;
 
     if (handler.events && handler.events[name]) {
-      handler.events[name].apply(handler, args);
-      return;
+      if (handler.events[name].apply(handler, args) === true) {
+        eventWasHandled = true;
+      } else {
+        return;
+      }
     }
   }
 
-  throw new Error("Nothing handled the event '" + name + "'.");
+  if (!eventWasHandled) {
+    throw new Error("Nothing handled the event '" + name + "'.");
+  }
 }
 
 function setContext(handler, context) {

--- a/dist/router.js
+++ b/dist/router.js
@@ -603,17 +603,24 @@
       throw new Error("Could not trigger event '" + name + "'. There are no active handlers");
     }
 
+    var eventWasHandled = false;
+
     for (var i=currentHandlerInfos.length-1; i>=0; i--) {
       var handlerInfo = currentHandlerInfos[i],
           handler = handlerInfo.handler;
 
       if (handler.events && handler.events[name]) {
-        handler.events[name].apply(handler, args);
-        return;
+        if (handler.events[name].apply(handler, args) === true) {
+          eventWasHandled = true;
+        } else {
+          return;
+        }
       }
     }
 
-    throw new Error("Nothing handled the event '" + name + "'.");
+    if (!eventWasHandled) {
+      throw new Error("Nothing handled the event '" + name + "'.");
+    }
   }
 
   function setContext(handler, context) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -603,17 +603,24 @@ function trigger(router, args) {
     throw new Error("Could not trigger event '" + name + "'. There are no active handlers");
   }
 
+  var eventWasHandled = false;
+
   for (var i=currentHandlerInfos.length-1; i>=0; i--) {
     var handlerInfo = currentHandlerInfos[i],
         handler = handlerInfo.handler;
 
     if (handler.events && handler.events[name]) {
-      handler.events[name].apply(handler, args);
-      return;
+      if (handler.events[name].apply(handler, args) === true) {
+        eventWasHandled = true;
+      } else {
+        return;
+      }
     }
   }
 
-  throw new Error("Nothing handled the event '" + name + "'.");
+  if (!eventWasHandled) {
+    throw new Error("Nothing handled the event '" + name + "'.");
+  }
 }
 
 function setContext(handler, context) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1183,6 +1183,74 @@ asyncTest("events can be targeted at a parent handler", function() {
   router.trigger("expand");
 });
 
+asyncTest("events can bubble up to a parent handler via `return true`", function() {
+  expect(4);
+
+  var postIndexHandler = {
+    enter: function() {
+      ok(true, "The post index handler was entered");
+    },
+
+    events: {
+      expand: function() {
+        equal(this, postIndexHandler, "The handler is the `this` in events");
+        start();
+      }
+    }
+  };
+
+  var showAllPostsHandler = {
+    enter: function() {
+      ok(true, "The show all posts handler was entered");
+    },
+    events: {
+      expand: function() {
+        equal(this, showAllPostsHandler, "The handler is the `this` in events");
+        return true;
+      }
+    }
+  }
+
+  handlers = {
+    postIndex: postIndexHandler,
+    showAllPosts: showAllPostsHandler
+  };
+
+  router.handleURL("/posts");
+  router.trigger("expand");
+});
+
+asyncTest("handled-then-bubbled events don't throw an exception if uncaught by parent route", function() {
+  expect(3);
+
+  var postIndexHandler = {
+    enter: function() {
+      ok(true, "The post index handler was entered");
+    }
+  };
+
+  var showAllPostsHandler = {
+    enter: function() {
+      ok(true, "The show all posts handler was entered");
+    },
+    events: {
+      expand: function() {
+        equal(this, showAllPostsHandler, "The handler is the `this` in events");
+        start();
+        return true;
+      }
+    }
+  }
+
+  handlers = {
+    postIndex: postIndexHandler,
+    showAllPosts: showAllPostsHandler
+  };
+
+  router.handleURL("/posts");
+  router.trigger("expand");
+});
+
 asyncTest("events only fire on the closest handler", function() {
   expect(5);
 


### PR DESCRIPTION
If you return true from an event handler, the
event will bubble up to a parent route. No exception
is thrown if an event was handled, bubbles, and isn't
handled again by a parent route.

This is a next step for Ember.js router work.
See https://github.com/emberjs/ember.js/pull/2522
