### PR TITLE
Invoke `enter` on failure handler

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -337,7 +337,10 @@ define("router",
     function failure(router, error) {
       loaded(router);
       var handler = router.getHandler('failure');
-      if (handler && handler.setup) { handler.setup(error); }
+      if (handler) {
+        if (handler.enter) { handler.enter(); }
+        if (handler.setup) { handler.setup(error); }
+      }
     }
 
     /**

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -335,7 +335,10 @@ function loaded(router) {
 function failure(router, error) {
   loaded(router);
   var handler = router.getHandler('failure');
-  if (handler && handler.setup) { handler.setup(error); }
+  if (handler) {
+    if (handler.enter) { handler.enter(); }
+    if (handler.setup) { handler.setup(error); }
+  }
 }
 
 /**

--- a/dist/router.js
+++ b/dist/router.js
@@ -335,7 +335,10 @@
   function failure(router, error) {
     loaded(router);
     var handler = router.getHandler('failure');
-    if (handler && handler.setup) { handler.setup(error); }
+    if (handler) {
+      if (handler.enter) { handler.enter(); }
+      if (handler.setup) { handler.setup(error); }
+    }
   }
 
   /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -335,7 +335,10 @@ function loaded(router) {
 function failure(router, error) {
   loaded(router);
   var handler = router.getHandler('failure');
-  if (handler && handler.setup) { handler.setup(error); }
+  if (handler) {
+    if (handler.enter) { handler.enter(); }
+    if (handler.setup) { handler.setup(error); }
+  }
 }
 
 /**


### PR DESCRIPTION
This is a migration from a change made to the Ember.js repo:

https://github.com/emberjs/ember.js/commit/b454c5f9b636ed6c880ed1e008d0bf13ee845631
