### PR TITLE
Router#reset exits & clears current route handlers

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -51,6 +51,21 @@ define("router",
       },
 
       /**
+        Clears the current and target route handlers and triggers exit
+        on each of them starting at the leaf and traversing up through
+        its ancestors.
+      */
+      reset: function() {
+        eachHandler(this.currentHandlerInfos, function(handler) {
+          if (handler.exit) {
+            handler.exit();
+          }
+        });
+        this.currentHandlerInfos = null;
+        this.targetHandlerInfos = null;
+      },
+
+      /**
         The entry point for handling a change to the URL (usually
         via the back and forward button).
 

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -49,6 +49,21 @@ Router.prototype = {
   },
 
   /**
+    Clears the current and target route handlers and triggers exit
+    on each of them starting at the leaf and traversing up through
+    its ancestors.
+  */
+  reset: function() {
+    eachHandler(this.currentHandlerInfos, function(handler) {
+      if (handler.exit) {
+        handler.exit();
+      }
+    });
+    this.currentHandlerInfos = null;
+    this.targetHandlerInfos = null;
+  },
+
+  /**
     The entry point for handling a change to the URL (usually
     via the back and forward button).
 

--- a/dist/router.js
+++ b/dist/router.js
@@ -49,6 +49,21 @@
     },
 
     /**
+      Clears the current and target route handlers and triggers exit
+      on each of them starting at the leaf and traversing up through
+      its ancestors.
+    */
+    reset: function() {
+      eachHandler(this.currentHandlerInfos, function(handler) {
+        if (handler.exit) {
+          handler.exit();
+        }
+      });
+      this.currentHandlerInfos = null;
+      this.targetHandlerInfos = null;
+    },
+
+    /**
       The entry point for handling a change to the URL (usually
       via the back and forward button).
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -49,6 +49,21 @@ Router.prototype = {
   },
 
   /**
+    Clears the current and target route handlers and triggers exit
+    on each of them starting at the leaf and traversing up through
+    its ancestors.
+  */
+  reset: function() {
+    eachHandler(this.currentHandlerInfos, function(handler) {
+      if (handler.exit) {
+        handler.exit();
+      }
+    });
+    this.currentHandlerInfos = null;
+    this.targetHandlerInfos = null;
+  },
+
+  /**
     The entry point for handling a change to the URL (usually
     via the back and forward button).
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1703,3 +1703,31 @@ test("A final handler can specify an additional non-routable handler", function(
   router.handleURL("/index");
   router.transitionTo('showPost', { id: 1 });
 });
+
+test("reset exits and clears the current and target route handlers", function() {
+  var postIndexExited = false;
+  var showAllPostsExited = false;
+
+  var postIndexHandler = {
+    exit: function() {
+      postIndexExited = true;
+    }
+  };
+  var showAllPostsHandler = {
+    exit: function() {
+      showAllPostsExited = true;
+    }
+  };
+  handlers = {
+    postIndex: postIndexHandler,
+    showAllPosts: showAllPostsHandler
+  };
+
+  router.handleURL("/posts/all");
+  router.reset();
+
+  ok(postIndexExited, "Post index handler did not exit");
+  ok(showAllPostsExited, "Show all posts handler did not exit");
+  equal(router.currentHandlerInfos, null, "currentHandlerInfos should be null");
+  equal(router.targetHandlerInfos, null, "targetHandlerInfos should be null");
+});


### PR DESCRIPTION
This is a pre-requisite for Ember.js [issue#2649](https://github.com/emberjs/ember.js/issues/2649) and [PR#2650](https://github.com/emberjs/ember.js/pull/2650)
