### PR TITLE
Tweaks to model resolution

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -343,14 +343,15 @@ define("router",
      */
     function getMatchPoint(router, handlers, objects, inputParams) {
 
-      var objectsToMatch = objects.length, 
+      var objects = slice.call(objects), 
           matchPoint = handlers.length, 
           providedModels = {}, i,
           currentHandlerInfos = router.currentHandlerInfos || [],
           params = {},
           oldParams = router.currentParams || {},
           activeTransition = router.activeTransition,
-          handlerParams = {};
+          handlerParams = {},
+          obj;
 
       merge(params, inputParams);
    
@@ -366,9 +367,9 @@ define("router",
         if (handlerObj.isDynamic) {
           // URL transition.
 
-          if (objectsToMatch > 0) {
+          if (obj = getMatchPointObject(objects, handlerName, activeTransition, true)) {
             hasChanged = true;
-            providedModels[handlerName] = objects[--objectsToMatch];
+            providedModels[handlerName] = obj;
           } else {
             handlerParams[handlerName] = {};
             for (var prop in handlerObj.params) {
@@ -378,18 +379,12 @@ define("router",
               handlerParams[handlerName][prop] = params[prop] = newParam;
             }
           }
-        } else if (handlerObj.hasOwnProperty('names') && handlerObj.names.length) {
+        } else if (handlerObj.hasOwnProperty('names')) {
           // Named transition.
 
-          if (objectsToMatch > 0) {
+          if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names.length)) {
             hasChanged = true;
-            providedModels[handlerName] = objects[--objectsToMatch];
-          } else if (activeTransition && activeTransition.providedModels[handlerName]) {
-
-            // Use model from previous transition attempt, preferably the resolved one.
-            hasChanged = true;
-            providedModels[handlerName] = activeTransition.providedModels[handlerName] ||
-                                          activeTransition.resolvedModels[handlerName];
+            providedModels[handlerName] = obj;
           } else {
             var names = handlerObj.names;
             handlerParams[handlerName] = {};
@@ -403,11 +398,21 @@ define("router",
         if (hasChanged) { matchPoint = i; }
       }
 
-      if (objectsToMatch > 0) {
+      if (objects.length > 0) {
         throw "More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler;
       }
 
       return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+    }
+
+    function getMatchPointObject(objects, handlerName, activeTransition, canUseProvidedObject) {
+      if (objects.length && canUseProvidedObject) {
+        return objects.pop();
+      } else if (activeTransition) {
+        // Use model from previous transition attempt, preferably the resolved one.
+        return (canUseProvidedObject && activeTransition.providedModels[handlerName]) ||
+               activeTransition.resolvedModels[handlerName];
+      } 
     }
 
     /**
@@ -882,15 +887,14 @@ define("router",
           handler = handlerInfo.handler,
           handlerName = handlerInfo.name,
           seq = transition.sequence,
-          errorAlreadyHandled = false,
-          resolvedModel;
+          errorAlreadyHandled = false;
 
       if (index < matchPoint) {
         log(router, seq, handlerName + ": using context from already-active handler");
 
         // We're before the match point, so don't run any hooks,
         // just use the already resolved context from the handler.
-        resolvedModel = handlerInfo.handler.context;
+        transition.resolvedModels[handlerInfo.name] = handlerInfo.handler.context;
         return proceed();
       }
 
@@ -930,8 +934,8 @@ define("router",
         trigger(handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
 
         if (handler.error) { 
-          handler.error(reason, transition); }
-
+          handler.error(reason, transition); 
+        }
 
         // Propagate the original error.
         return RSVP.reject(reason);
@@ -958,14 +962,14 @@ define("router",
         // want to use the value returned from `afterModel` in any way, but rather
         // always resolve with the original `context` object.
 
-        resolvedModel = context;
-        return handler.afterModel && handler.afterModel(resolvedModel, transition);
+        transition.resolvedModels[handlerInfo.name] = context;
+        return handler.afterModel && handler.afterModel(context, transition);
       }
 
       function proceed() {
         log(router, seq, handlerName + ": validation succeeded, proceeding");
 
-        handlerInfo.context = transition.resolvedModels[handlerInfo.name] = resolvedModel;
+        handlerInfo.context = transition.resolvedModels[handlerInfo.name];
         return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
       }
     }
@@ -997,7 +1001,7 @@ define("router",
         return handler.context;
       }
 
-      if (handlerInfo.isDynamic && transition.providedModels.hasOwnProperty(handlerName)) {
+      if (transition.providedModels.hasOwnProperty(handlerName)) {
         var providedModel = transition.providedModels[handlerName];
         return typeof providedModel === 'function' ? providedModel() : providedModel;
       }

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -342,14 +342,15 @@ Router.prototype = {
  */
 function getMatchPoint(router, handlers, objects, inputParams) {
 
-  var objectsToMatch = objects.length, 
+  var objects = slice.call(objects), 
       matchPoint = handlers.length, 
       providedModels = {}, i,
       currentHandlerInfos = router.currentHandlerInfos || [],
       params = {},
       oldParams = router.currentParams || {},
       activeTransition = router.activeTransition,
-      handlerParams = {};
+      handlerParams = {},
+      obj;
 
   merge(params, inputParams);
    
@@ -365,9 +366,9 @@ function getMatchPoint(router, handlers, objects, inputParams) {
     if (handlerObj.isDynamic) {
       // URL transition.
 
-      if (objectsToMatch > 0) {
+      if (obj = getMatchPointObject(objects, handlerName, activeTransition, true)) {
         hasChanged = true;
-        providedModels[handlerName] = objects[--objectsToMatch];
+        providedModels[handlerName] = obj;
       } else {
         handlerParams[handlerName] = {};
         for (var prop in handlerObj.params) {
@@ -377,18 +378,12 @@ function getMatchPoint(router, handlers, objects, inputParams) {
           handlerParams[handlerName][prop] = params[prop] = newParam;
         }
       }
-    } else if (handlerObj.hasOwnProperty('names') && handlerObj.names.length) {
+    } else if (handlerObj.hasOwnProperty('names')) {
       // Named transition.
 
-      if (objectsToMatch > 0) {
+      if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names.length)) {
         hasChanged = true;
-        providedModels[handlerName] = objects[--objectsToMatch];
-      } else if (activeTransition && activeTransition.providedModels[handlerName]) {
-
-        // Use model from previous transition attempt, preferably the resolved one.
-        hasChanged = true;
-        providedModels[handlerName] = activeTransition.providedModels[handlerName] ||
-                                      activeTransition.resolvedModels[handlerName];
+        providedModels[handlerName] = obj;
       } else {
         var names = handlerObj.names;
         handlerParams[handlerName] = {};
@@ -402,11 +397,21 @@ function getMatchPoint(router, handlers, objects, inputParams) {
     if (hasChanged) { matchPoint = i; }
   }
 
-  if (objectsToMatch > 0) {
+  if (objects.length > 0) {
     throw "More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler;
   }
 
   return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+}
+
+function getMatchPointObject(objects, handlerName, activeTransition, canUseProvidedObject) {
+  if (objects.length && canUseProvidedObject) {
+    return objects.pop();
+  } else if (activeTransition) {
+    // Use model from previous transition attempt, preferably the resolved one.
+    return (canUseProvidedObject && activeTransition.providedModels[handlerName]) ||
+           activeTransition.resolvedModels[handlerName];
+  } 
 }
 
 /**
@@ -881,15 +886,14 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
       handler = handlerInfo.handler,
       handlerName = handlerInfo.name,
       seq = transition.sequence,
-      errorAlreadyHandled = false,
-      resolvedModel;
+      errorAlreadyHandled = false;
 
   if (index < matchPoint) {
     log(router, seq, handlerName + ": using context from already-active handler");
 
     // We're before the match point, so don't run any hooks,
     // just use the already resolved context from the handler.
-    resolvedModel = handlerInfo.handler.context;
+    transition.resolvedModels[handlerInfo.name] = handlerInfo.handler.context;
     return proceed();
   }
 
@@ -929,8 +933,8 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     trigger(handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
 
     if (handler.error) { 
-      handler.error(reason, transition); }
-
+      handler.error(reason, transition); 
+    }
 
     // Propagate the original error.
     return RSVP.reject(reason);
@@ -957,14 +961,14 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     // want to use the value returned from `afterModel` in any way, but rather
     // always resolve with the original `context` object.
 
-    resolvedModel = context;
-    return handler.afterModel && handler.afterModel(resolvedModel, transition);
+    transition.resolvedModels[handlerInfo.name] = context;
+    return handler.afterModel && handler.afterModel(context, transition);
   }
 
   function proceed() {
     log(router, seq, handlerName + ": validation succeeded, proceeding");
 
-    handlerInfo.context = transition.resolvedModels[handlerInfo.name] = resolvedModel;
+    handlerInfo.context = transition.resolvedModels[handlerInfo.name];
     return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
   }
 }
@@ -996,7 +1000,7 @@ function getModel(handlerInfo, transition, handlerParams, needsUpdate) {
     return handler.context;
   }
 
-  if (handlerInfo.isDynamic && transition.providedModels.hasOwnProperty(handlerName)) {
+  if (transition.providedModels.hasOwnProperty(handlerName)) {
     var providedModel = transition.providedModels[handlerName];
     return typeof providedModel === 'function' ? providedModel() : providedModel;
   }

--- a/lib/router.js
+++ b/lib/router.js
@@ -342,14 +342,15 @@ Router.prototype = {
  */
 function getMatchPoint(router, handlers, objects, inputParams) {
 
-  var objectsToMatch = objects.length, 
+  var objects = slice.call(objects), 
       matchPoint = handlers.length, 
       providedModels = {}, i,
       currentHandlerInfos = router.currentHandlerInfos || [],
       params = {},
       oldParams = router.currentParams || {},
       activeTransition = router.activeTransition,
-      handlerParams = {};
+      handlerParams = {},
+      obj;
 
   merge(params, inputParams);
    
@@ -365,9 +366,9 @@ function getMatchPoint(router, handlers, objects, inputParams) {
     if (handlerObj.isDynamic) {
       // URL transition.
 
-      if (objectsToMatch > 0) {
+      if (obj = getMatchPointObject(objects, handlerName, activeTransition, true)) {
         hasChanged = true;
-        providedModels[handlerName] = objects[--objectsToMatch];
+        providedModels[handlerName] = obj;
       } else {
         handlerParams[handlerName] = {};
         for (var prop in handlerObj.params) {
@@ -377,18 +378,12 @@ function getMatchPoint(router, handlers, objects, inputParams) {
           handlerParams[handlerName][prop] = params[prop] = newParam;
         }
       }
-    } else if (handlerObj.hasOwnProperty('names') && handlerObj.names.length) {
+    } else if (handlerObj.hasOwnProperty('names')) {
       // Named transition.
 
-      if (objectsToMatch > 0) {
+      if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names.length)) {
         hasChanged = true;
-        providedModels[handlerName] = objects[--objectsToMatch];
-      } else if (activeTransition && activeTransition.providedModels[handlerName]) {
-
-        // Use model from previous transition attempt, preferably the resolved one.
-        hasChanged = true;
-        providedModels[handlerName] = activeTransition.providedModels[handlerName] ||
-                                      activeTransition.resolvedModels[handlerName];
+        providedModels[handlerName] = obj;
       } else {
         var names = handlerObj.names;
         handlerParams[handlerName] = {};
@@ -402,11 +397,21 @@ function getMatchPoint(router, handlers, objects, inputParams) {
     if (hasChanged) { matchPoint = i; }
   }
 
-  if (objectsToMatch > 0) {
+  if (objects.length > 0) {
     throw "More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler;
   }
 
   return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+}
+
+function getMatchPointObject(objects, handlerName, activeTransition, canUseProvidedObject) {
+  if (objects.length && canUseProvidedObject) {
+    return objects.pop();
+  } else if (activeTransition) {
+    // Use model from previous transition attempt, preferably the resolved one.
+    return (canUseProvidedObject && activeTransition.providedModels[handlerName]) ||
+           activeTransition.resolvedModels[handlerName];
+  } 
 }
 
 /**
@@ -881,15 +886,14 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
       handler = handlerInfo.handler,
       handlerName = handlerInfo.name,
       seq = transition.sequence,
-      errorAlreadyHandled = false,
-      resolvedModel;
+      errorAlreadyHandled = false;
 
   if (index < matchPoint) {
     log(router, seq, handlerName + ": using context from already-active handler");
 
     // We're before the match point, so don't run any hooks,
     // just use the already resolved context from the handler.
-    resolvedModel = handlerInfo.handler.context;
+    transition.resolvedModels[handlerInfo.name] = handlerInfo.handler.context;
     return proceed();
   }
 
@@ -929,8 +933,8 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     trigger(handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
 
     if (handler.error) { 
-      handler.error(reason, transition); }
-
+      handler.error(reason, transition); 
+    }
 
     // Propagate the original error.
     return RSVP.reject(reason);
@@ -957,14 +961,14 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     // want to use the value returned from `afterModel` in any way, but rather
     // always resolve with the original `context` object.
 
-    resolvedModel = context;
-    return handler.afterModel && handler.afterModel(resolvedModel, transition);
+    transition.resolvedModels[handlerInfo.name] = context;
+    return handler.afterModel && handler.afterModel(context, transition);
   }
 
   function proceed() {
     log(router, seq, handlerName + ": validation succeeded, proceeding");
 
-    handlerInfo.context = transition.resolvedModels[handlerInfo.name] = resolvedModel;
+    handlerInfo.context = transition.resolvedModels[handlerInfo.name];
     return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
   }
 }
@@ -996,7 +1000,7 @@ function getModel(handlerInfo, transition, handlerParams, needsUpdate) {
     return handler.context;
   }
 
-  if (handlerInfo.isDynamic && transition.providedModels.hasOwnProperty(handlerName)) {
+  if (transition.providedModels.hasOwnProperty(handlerName)) {
     var providedModel = transition.providedModels[handlerName];
     return typeof providedModel === 'function' ? providedModel() : providedModel;
   }


### PR DESCRIPTION
I rearranged some code to address to somewhat related issues:

1) Don't re-call `model` on a parent route in a redirect if
the parent model already resolved.

This causes this Ember.js test case to pass:

https://github.com/emberjs/ember.js/pull/2874

2) Make it possible to swap out the resolved model within afterModel

This is something that's been requested by @ghempton and @ebryn; after
a model has resolved, there are use cases where you might want to
perform some transformation on it that involves entirely swapping
the model rather than just setting properties on this. One way we
could have allowed for this would be to use the return value from
afterModel as the final resolved model that'll be passed to `setup`,
but this would awkwardly require that anyone who doesn't want to
swap out the resolved model would have to always return the
`resolvedModel` that was passed into `afterModel`, which seems like
crappy API.

So the more conservative approach taken in this PR is to allow
adventurous users to swap out the resolved model in
`transition.resolvedModels[routeName]`. This wasn't possible
before this PR as that value would have been clobbered
after resolving `afterModel`.
