### PR TITLE
.retry() preserves params of aborted URL transition

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -390,7 +390,7 @@ define("router",
             handlerParams[handlerName] = {};
             for (var j = 0, len = names.length; j < len; ++j) {
               var name = names[j];
-              handlerParams[handlerName][name] = params[name] = oldParams[name];
+              handlerParams[handlerName][name] = params[name] = oldParams[name] || params[name];
             }
           }
         } 

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -389,7 +389,7 @@ function getMatchPoint(router, handlers, objects, inputParams) {
         handlerParams[handlerName] = {};
         for (var j = 0, len = names.length; j < len; ++j) {
           var name = names[j];
-          handlerParams[handlerName][name] = params[name] = oldParams[name];
+          handlerParams[handlerName][name] = params[name] = oldParams[name] || params[name];
         }
       }
     } 

--- a/dist/router.js
+++ b/dist/router.js
@@ -388,7 +388,7 @@
           handlerParams[handlerName] = {};
           for (var j = 0, len = names.length; j < len; ++j) {
             var name = names[j];
-            handlerParams[handlerName][name] = params[name] = oldParams[name];
+            handlerParams[handlerName][name] = params[name] = oldParams[name] || params[name];
           }
         }
       } 

--- a/lib/router.js
+++ b/lib/router.js
@@ -389,7 +389,7 @@ function getMatchPoint(router, handlers, objects, inputParams) {
         handlerParams[handlerName] = {};
         for (var j = 0, len = names.length; j < len; ++j) {
           var name = names[j];
-          handlerParams[handlerName][name] = params[name] = oldParams[name];
+          handlerParams[handlerName][name] = params[name] = oldParams[name] || params[name];
         }
       }
     } 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1956,7 +1956,16 @@ function setupAuthenticatedExample() {
         start();
       }
     },
-    adminPost: { }
+    adminPost: { 
+      model: function(params) {
+        deepEqual(params, { post_id: '5' }, "adminPost received params previous transition attempt");
+        return "adminPost";
+      },
+      setup: function(model) {
+        equal(model, "adminPost", "adminPost was entered with correct model");
+        start();
+      }
+    }
   };
 }
 
@@ -2003,6 +2012,17 @@ asyncTest("authenticated routes: starting on auth route", function() {
     equal(result.name, "TransitionAborted", "transition from login to restricted about was redirected back to login");
 
     // Log in. This will retry the last failed transition to 'about'.
+    router.trigger('logUserIn');
+  });
+});
+
+asyncTest("authenticated routes: starting on parameterized auth route", function() {
+  expect(4);
+
+  setupAuthenticatedExample();
+
+  router.handleURL('/admin/posts/5').then(shouldNotHappen, function(result) {
+    // Log in. This will retry the last failed transition to '/posts/5'.
     router.trigger('logUserIn');
   });
 });


### PR DESCRIPTION
Fixes the root cause of:
https://github.com/emberjs/ember.js/issues/2897
