### PR TITLE
transitionTo and paramsForHandler treat string/number as params

### DIFF
--- a/dist/router.js
+++ b/dist/router.js
@@ -365,7 +365,7 @@
       if (handlerObj.isDynamic) {
         // URL transition.
 
-        if (obj = getMatchPointObject(objects, handlerName, activeTransition, true)) {
+        if (obj = getMatchPointObject(objects, handlerName, activeTransition, true, params)) {
           hasChanged = true;
           providedModels[handlerName] = obj;
         } else {
@@ -380,15 +380,16 @@
       } else if (handlerObj.hasOwnProperty('names')) {
         // Named transition.
 
-        if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names.length)) {
-          hasChanged = true;
+        if (objects.length) { hasChanged = true; }
+
+        if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names[0], params)) {
           providedModels[handlerName] = obj;
         } else {
           var names = handlerObj.names;
           handlerParams[handlerName] = {};
           for (var j = 0, len = names.length; j < len; ++j) {
             var name = names[j];
-            handlerParams[handlerName][name] = params[name] = oldParams[name] || params[name];
+            handlerParams[handlerName][name] = params[name] = params[name] || oldParams[name];
           }
         }
       } 
@@ -403,14 +404,27 @@
     return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
   }
 
-  function getMatchPointObject(objects, handlerName, activeTransition, canUseProvidedObject) {
-    if (objects.length && canUseProvidedObject) {
-      return objects.pop();
+  function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
+
+    if (objects.length && paramName) {
+
+      var object = objects.pop();
+
+      // If provided object is string or number, treat as param.
+      if (isParam(object)) {
+        params[paramName] = object.toString();
+      } else {
+        return object;
+      }
     } else if (activeTransition) {
       // Use model from previous transition attempt, preferably the resolved one.
-      return (canUseProvidedObject && activeTransition.providedModels[handlerName]) ||
+      return (paramName && activeTransition.providedModels[handlerName]) ||
              activeTransition.resolvedModels[handlerName];
     } 
+  }
+
+  function isParam(object) {
+    return object && (typeof object === "string" || object instanceof String || !isNaN(object));
   }
 
   /**
@@ -1058,6 +1072,12 @@
   */
   function serialize(handler, model, names) {
 
+    var object = {};
+    if (isParam(model)) {
+      object[names[0]] = model;
+      return object;
+    }
+
     // Use custom serialize if it exists.
     if (handler.serialize) {
       return handler.serialize(model, names);
@@ -1065,7 +1085,7 @@
 
     if (names.length !== 1) { return; }
 
-    var name = names[0], object = {};
+    var name = names[0];
 
     if (/_id$/.test(name)) {
       object[name] = model.id;


### PR DESCRIPTION
`transitionTo` and `paramsForHandler` now treat string/number
as params that will be passed to model. This is useful for
when you want to call transitionTo, but don't have a model
to provide, don't want to provide one, or want to unify
model loading/resolving with however `model` decides to do
this.
