### PR TITLE
handleURL can handle slashless urls

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -220,7 +220,9 @@ define("router",
       handleURL: function(url) {
         // Perform a URL-based transition, but don't change
         // the URL afterward, since it already happened.
-        return doTransition(this, arguments).method(null);
+        var args = slice.call(arguments);
+        if (url.charAt(0) !== '/') { args[0] = '/' + url; }
+        return doTransition(this, args).method(null);
       },
 
       /**

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -219,7 +219,9 @@ Router.prototype = {
   handleURL: function(url) {
     // Perform a URL-based transition, but don't change
     // the URL afterward, since it already happened.
-    return doTransition(this, arguments).method(null);
+    var args = slice.call(arguments);
+    if (url.charAt(0) !== '/') { args[0] = '/' + url; }
+    return doTransition(this, args).method(null);
   },
 
   /**

--- a/dist/router.js
+++ b/dist/router.js
@@ -218,7 +218,9 @@
     handleURL: function(url) {
       // Perform a URL-based transition, but don't change
       // the URL afterward, since it already happened.
-      return doTransition(this, arguments).method(null);
+      var args = slice.call(arguments);
+      if (url.charAt(0) !== '/') { args[0] = '/' + url; }
+      return doTransition(this, args).method(null);
     },
 
     /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -219,7 +219,9 @@ Router.prototype = {
   handleURL: function(url) {
     // Perform a URL-based transition, but don't change
     // the URL afterward, since it already happened.
-    return doTransition(this, arguments).method(null);
+    var args = slice.call(arguments);
+    if (url.charAt(0) !== '/') { args[0] = '/' + url; }
+    return doTransition(this, args).method(null);
   },
 
   /**

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -99,6 +99,21 @@ asyncTest("Handling a URL triggers model on the handler and passes the result in
   router.handleURL("/posts/1").then(start, shouldNotHappen);
 });
 
+asyncTest("handleURL accepts slash-less URLs", function() {
+
+  handlers = {
+    posts: {},
+    postIndex: {},
+    showAllPosts: {
+      setup: function() {
+        ok(true, "showAllPosts' setup called");
+      }
+    }
+  };
+
+  router.handleURL("posts/all").then(start);
+});
+
 asyncTest("when transitioning with the same context, setup should only be called once", function() {
   var parentSetupCount = 0,
       childSetupCount = 0;


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/2915

This is mostly a backwards for backwards compatibility; router.js doesn't seem to generate url's without slashes. 
