### PR TITLE
handle transition as return value in beforeModel and afterModel

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -961,13 +961,15 @@ define("router",
 
         log(router, seq, handlerName + ": calling beforeModel hook");
 
-        return handler.beforeModel && handler.beforeModel(transition);
+        var p = handler.beforeModel && handler.beforeModel(transition);
+        return (p instanceof Transition) ? null : p;
       }
 
       function model() {
         log(router, seq, handlerName + ": resolving model");
 
-        return getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+        var p = getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+        return (p instanceof Transition) ? null : p;
       }
 
       function afterModel(context) {
@@ -979,7 +981,9 @@ define("router",
         // always resolve with the original `context` object.
 
         transition.resolvedModels[handlerInfo.name] = context;
-        return handler.afterModel && handler.afterModel(context, transition);
+
+        var p = handler.afterModel && handler.afterModel(context, transition);
+        return (p instanceof Transition) ? null : p;
       }
 
       function proceed() {

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -960,13 +960,15 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
 
     log(router, seq, handlerName + ": calling beforeModel hook");
 
-    return handler.beforeModel && handler.beforeModel(transition);
+    var p = handler.beforeModel && handler.beforeModel(transition);
+    return (p instanceof Transition) ? null : p;
   }
 
   function model() {
     log(router, seq, handlerName + ": resolving model");
 
-    return getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+    var p = getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+    return (p instanceof Transition) ? null : p;
   }
 
   function afterModel(context) {
@@ -978,7 +980,9 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     // always resolve with the original `context` object.
 
     transition.resolvedModels[handlerInfo.name] = context;
-    return handler.afterModel && handler.afterModel(context, transition);
+
+    var p = handler.afterModel && handler.afterModel(context, transition);
+    return (p instanceof Transition) ? null : p;
   }
 
   function proceed() {

--- a/dist/router.js
+++ b/dist/router.js
@@ -959,13 +959,15 @@
 
       log(router, seq, handlerName + ": calling beforeModel hook");
 
-      return handler.beforeModel && handler.beforeModel(transition);
+      var p = handler.beforeModel && handler.beforeModel(transition);
+      return (p instanceof Transition) ? null : p;
     }
 
     function model() {
       log(router, seq, handlerName + ": resolving model");
 
-      return getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+      var p = getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+      return (p instanceof Transition) ? null : p;
     }
 
     function afterModel(context) {
@@ -977,7 +979,9 @@
       // always resolve with the original `context` object.
 
       transition.resolvedModels[handlerInfo.name] = context;
-      return handler.afterModel && handler.afterModel(context, transition);
+
+      var p = handler.afterModel && handler.afterModel(context, transition);
+      return (p instanceof Transition) ? null : p;
     }
 
     function proceed() {

--- a/lib/router.js
+++ b/lib/router.js
@@ -960,13 +960,15 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
 
     log(router, seq, handlerName + ": calling beforeModel hook");
 
-    return handler.beforeModel && handler.beforeModel(transition);
+    var p = handler.beforeModel && handler.beforeModel(transition);
+    return (p instanceof Transition) ? null : p;
   }
 
   function model() {
     log(router, seq, handlerName + ": resolving model");
 
-    return getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+    var p = getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
+    return (p instanceof Transition) ? null : p;
   }
 
   function afterModel(context) {
@@ -978,7 +980,9 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     // always resolve with the original `context` object.
 
     transition.resolvedModels[handlerInfo.name] = context;
-    return handler.afterModel && handler.afterModel(context, transition);
+
+    var p = handler.afterModel && handler.afterModel(context, transition);
+    return (p instanceof Transition) ? null : p;
   }
 
   function proceed() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2292,3 +2292,57 @@ asyncTest("String/number args in transitionTo are treated as url params", functi
   }, shouldNotHappen);
 });
 
+asyncTest("Transitions returned from beforeModel/model/afterModel hooks aren't treated as pausing promises", function(){
+
+  expect(6);
+
+  handlers = {
+
+    index: {
+      beforeModel: function() {
+        ok(true, 'index beforeModel called');
+        return router.transitionTo('index');
+      },
+      model: function(){
+        ok(true, 'index model called');
+        return router.transitionTo('index');
+      },
+      afterModel: function(){
+        ok(true, 'index afterModel called');
+        return router.transitionTo('index');
+      }
+    }
+
+  };
+
+  function testStartup(){
+
+    router = new Router();
+
+    router.getHandler = function(name) {
+      return handlers[name];
+    };
+
+    router.updateURL = function() { };
+
+    router.map(function(match) {
+      match("/index").to('index');
+    });
+
+    return router.handleURL('/index');
+  }
+
+  testStartup().then(function(result) {
+    delete handlers.index.beforeModel;
+    return testStartup();
+  }).then(function(result) {
+    delete handlers.index.model;
+    return testStartup();
+  }).then(function(result) {
+    delete handlers.index.afterModel;
+    return testStartup();
+  }).then(function(result) {
+    start();
+  });
+
+});


### PR DESCRIPTION
This is an attempt to fix #34

As said in the issue, it can easily happen for coffeescript users to accidentally return a transition within a beforeModel or and afterModel hook.

After a chat with @machty I've handled this situation as a special case.

This PR handles only the beforeModel and afterModel hooks
I'm not sure if and how to proceed in the model hook (shall people be able to even call transitionTo in a model hook?)

Assuming that this is the right approach let me know if you need any change to the code.
