### PR TITLE
Use es6-module-transpiler and update to latest ES6 module syntax.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "js_module_transpiler", github: "wycats/js_module_transpiler", branch: "master"
 gem "qunit-cli-runner", github: "wagenet/qunit-cli-runner", branch: "master"
 gem "rake"
 gem "aws-sdk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
     qunit-cli-runner (0.0.1)
       colored
 
-GIT
-  remote: git://github.com/wycats/js_module_transpiler.git
-  revision: c9f0ada0f7b7ec654ddec25f4a1fb07bcf41c9f7
-  branch: master
-  specs:
-    js_module_transpiler (0.0.1)
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,7 +17,6 @@ GEM
     json (1.8.0)
     nokogiri (1.5.9)
     rake (10.0.2)
-    thor (0.16.0)
     uuidtools (2.1.4)
 
 PLATFORMS
@@ -33,6 +24,5 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk
-  js_module_transpiler!
   qunit-cli-runner!
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-directory "dist"
-
 def replace_debug(file)
   content = File.read(file)
 
@@ -13,7 +11,7 @@ def replace_debug(file)
 end
 
 require "bundler/setup"
-require "js_module_transpiler"
+require File.expand_path("../tasks/support/js_module_transpiler", __FILE__)
 require 'qunit-cli-runner'
 
 directory "dist"

--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -1,5 +1,5 @@
 define("router",
-  ["route-recognizer", "rsvp"],
+  ["route-recognizer","rsvp"],
   function(RouteRecognizer, RSVP) {
     "use strict";
     /**
@@ -1102,6 +1102,7 @@ define("router",
       }
       return object;
     }
+
 
     return Router;
   });

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -1102,4 +1102,5 @@ function serialize(handler, model, names) {
   return object;
 }
 
+
 module.exports = Router;

--- a/dist/router.js
+++ b/dist/router.js
@@ -1101,5 +1101,6 @@
     return object;
   }
 
+
   exports.Router = Router;
 })(window, window.RouteRecognizer, window.RSVP);

--- a/lib/router.js
+++ b/lib/router.js
@@ -16,8 +16,8 @@
   * `{Object} context`: the active context for the handler
 */
 
-import "route-recognizer" as RouteRecognizer;
-import "rsvp" as RSVP;
+import RouteRecognizer from "route-recognizer";
+import RSVP from "rsvp";
 
 var slice = Array.prototype.slice;
 
@@ -140,7 +140,7 @@ function Router() {
   this.recognizer = new RouteRecognizer();
 }
 
-export = Router;
+export default Router;
 
 
 /**

--- a/tasks/support/js_module_transpiler.rb
+++ b/tasks/support/js_module_transpiler.rb
@@ -1,0 +1,69 @@
+# This is a shim that looks like the JsModuleTranspiler from
+# https://github.com/wycats/js_module_transpiler but uses the ES6 Module
+# Transpiler from https://github.com/square/es6-module-transpiler.
+module JsModuleTranspiler
+  class Compiler
+    def initialize(script, name, options={})
+      @script  = script
+      @name    = name
+      @options = options
+    end
+
+    def to_amd
+      transpile :amd
+    end
+
+    def to_cjs
+      transpile :cjs
+    end
+
+    def to_globals
+      transpile :globals
+    end
+
+    private
+
+    attr_reader :script, :name, :options
+
+    def transpile(type)
+      ensure_es6_transpiler_package_installed
+
+      args = [es6_transpiler_binary]
+      args << '--type' << type.to_s
+      args << '--stdio'
+
+      case type
+      when :globals
+        if options[:imports]
+          imports = options[:imports].map {|path,global| "#{path}:#{global}" }.join(',')
+          args << '--imports' << imports
+        end
+
+        if options[:into]
+          args << '--global' << options[:into]
+        end
+      when :amd
+        if name
+          args << '--module-name' << name
+        else
+          args << '--anonymous'
+        end
+      end
+
+      IO.popen(args, 'w+') do |io|
+        io << script
+        io.close_write
+        return io.read
+      end
+    end
+
+    def ensure_es6_transpiler_package_installed
+      return if File.executable?(es6_transpiler_binary)
+      %x{npm install es6-module-transpiler}
+    end
+
+    def es6_transpiler_binary
+      './node_modules/.bin/compile-modules'
+    end
+  end
+end


### PR DESCRIPTION
In order to make minimal changes to the project I added a shim that looks like the `Compiler` class from the js_module_transpiler project but uses es6-module-transpiler internally.
