### PR TITLE
remove duplicated `handleError`s from the model validation promise chain

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -910,8 +910,7 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
       handlerInfo = handlerInfos[index],
       handler = handlerInfo.handler,
       handlerName = handlerInfo.name,
-      seq = transition.sequence,
-      errorAlreadyHandled = false;
+      seq = transition.sequence;
 
   if (index < matchPoint) {
     log(router, seq, handlerName + ": using context from already-active handler");
@@ -924,21 +923,17 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
 
   return RSVP.resolve().then(handleAbort)
                        .then(beforeModel)
-                       .then(null, handleError)
                        .then(handleAbort)
                        .then(model)
-                       .then(null, handleError)
                        .then(handleAbort)
                        .then(afterModel)
-                       .then(null, handleError)
                        .then(handleAbort)
-                       .then(proceed);
+                       .then(proceed)
+                       .then(null, handleError);
 
   function handleAbort(result) {
-
-    if (transition.isAborted) { 
+    if (transition.isAborted) {
       log(transition.router, transition.sequence, "detected abort.");
-      errorAlreadyHandled = true;
       return RSVP.reject(new Router.TransitionAborted());
     }
 
@@ -946,9 +941,13 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
   }
 
   function handleError(reason) {
+    if (reason instanceof Router.TransitionAborted) {
+      // if the transition was aborted and *no additional* error was thrown,
+      // reject with the Router.TransitionAborted instance
+      return RSVP.reject(reason);
+    }
 
-    if (errorAlreadyHandled) { return RSVP.reject(reason); }
-    errorAlreadyHandled = true;
+    // otherwise, we're here because of a different error
     transition.abort();
 
     log(router, seq, handlerName + ": handling error: " + reason);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1542,6 +1542,95 @@ asyncTest("error handler gets called for errors in validation hooks", function()
   }, shouldNotHappen);
 });
 
+asyncTest("error handler gets called for errors in validation hooks, even if transition.abort was also called", function() {
+  expect(25);
+  var expectedReason = { reason: 'I am an error!' };
+  var returnPromise = false;
+  function aborTransitionAndThrowAnError() {
+    var transition = arguments[arguments.length - 1];
+    transition.abort();
+    // abort, but also reject the promise for a different reason
+    if (returnPromise) {
+      return RSVP.reject(expectedReason);
+    } else {
+      throw expectedReason;
+    }
+  }
+
+
+  handlers = {
+    index: {
+      beforeModel: aborTransitionAndThrowAnError,
+      model: aborTransitionAndThrowAnError,
+      afterModel: aborTransitionAndThrowAnError,
+
+      events: {
+        error: function(reason) {
+          equal(reason, expectedReason, "the value passed to the error handler is what was 'thrown' from the hook");
+        },
+      },
+
+      setup: function() {
+        ok(setupShouldBeEntered, "setup should be entered at this time");
+      }
+    },
+
+    about: {
+      setup: function() {
+        ok(true, "about handler's setup function was called");
+      }
+    }
+  };
+
+  function testStartup() {
+    router = new Router();
+
+    router.getHandler = function(name) {
+      return handlers[name];
+    };
+
+    router.updateURL = function() { };
+
+    router.map(function(match) {
+      match("/").to('index');
+      match("/about").to('about');
+    });
+
+    // Perform a redirect on startup.
+    return router.handleURL('/').then(null, function(reason) {
+      equal(reason, expectedReason, "handleURL error reason is what was originally thrown");
+
+      return router.transitionTo('index').then(null, function(newReason) {
+        equal(newReason, expectedReason, "transitionTo error reason is what was originally thrown");
+      });
+    });
+  }
+
+  testStartup().then(function(result) {
+    returnPromise = true;
+    return testStartup();
+  }).then(function(result) {
+    delete handlers.index.beforeModel;
+    returnPromise = false;
+    return testStartup();
+  }).then(function(result) {
+    returnPromise = true;
+    return testStartup();
+  }).then(function(result) {
+    delete handlers.index.model;
+    returnPromise = false;
+    return testStartup();
+  }).then(function(result) {
+    returnPromise = true;
+    return testStartup();
+  }).then(function(result) {
+    delete handlers.index.afterModel;
+    setupShouldBeEntered = true;
+    return testStartup();
+  }).then(function(result) {
+    setTimeout(start, 200);
+  }, shouldNotHappen);
+});
 
 asyncTest("can redirect from error handler", function() {
 


### PR DESCRIPTION
Both `transaction.abort()`, by way of the `handleAbort` method, and any errors thrown, or explicit `RSVP.reject`s returned, will make their way to the `handleError` catch at the end of the chain.

It is possible for (before/after)`model` to call `transaction.abort()` and **also** throw an error.  In this case, by the time we reach `handleError`, `transaction.isAborted === true`, but we still want to trigger the `error` handler.  To do so we check the `reason` explicitly to see if it is a `Router.TransitionAborted`.
