### PR TITLE
Add a package.json so that npm installs modules in the root of this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "router.js",
+  "version": "0.0.0",
+  "description": "A dummy package.json file for installing node_modules",
+  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tildeio/router.js.git"
+  }
+}


### PR DESCRIPTION
Without this package.json it's possible that "npm install es6-module-transpiler" installs packages somewhere outside of the root directory of this root (if some parent dir contains a package.json or node_modules). At least that's what happened to me.
