### PR TITLE
Fix argument name in `Router#paramsForHandler`

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -279,7 +279,7 @@ define("router",
         @param {Array[Object]} contexts
         @return {Object} a serialized parameter hash
       */
-      paramsForHandler: function(handlerName, callback) {
+      paramsForHandler: function(handlerName, contexts) {
         return paramsForHandler(this, handlerName, slice.call(arguments, 1));
       },
 

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -278,7 +278,7 @@ Router.prototype = {
     @param {Array[Object]} contexts
     @return {Object} a serialized parameter hash
   */
-  paramsForHandler: function(handlerName, callback) {
+  paramsForHandler: function(handlerName, contexts) {
     return paramsForHandler(this, handlerName, slice.call(arguments, 1));
   },
 

--- a/dist/router.js
+++ b/dist/router.js
@@ -277,7 +277,7 @@
       @param {Array[Object]} contexts
       @return {Object} a serialized parameter hash
     */
-    paramsForHandler: function(handlerName, callback) {
+    paramsForHandler: function(handlerName, contexts) {
       return paramsForHandler(this, handlerName, slice.call(arguments, 1));
     },
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -278,7 +278,7 @@ Router.prototype = {
     @param {Array[Object]} contexts
     @return {Object} a serialized parameter hash
   */
-  paramsForHandler: function(handlerName, callback) {
+  paramsForHandler: function(handlerName, contexts) {
     return paramsForHandler(this, handlerName, slice.call(arguments, 1));
   },
 


### PR DESCRIPTION
`Router#paramsForHandler` can be given objects as its contexts.
