### PR TITLE
Introduce a didTransition event, fired on the entered route.

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -808,7 +808,7 @@ define("router",
       @private
 
       This function is called when transitioning from one URL to
-      another to determine which handlers are not longer active,
+      another to determine which handlers are no longer active,
       which handlers are newly active, and which handlers remain
       active but have their context changed.
 
@@ -1002,6 +1002,9 @@ define("router",
               currentHandlerInfos.length !== matchPointResults.matchPoint) {
             finalizeTransition(transition, handlerInfos);
           }
+
+          // currentHandlerInfos was updated in finalizeTransition
+          trigger(router, router.currentHandlerInfos, true, ['didTransition']);
 
           if (router.didTransition) {
             router.didTransition(handlerInfos);

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -807,7 +807,7 @@ function queryParamsEqual(a, b) {
   @private
 
   This function is called when transitioning from one URL to
-  another to determine which handlers are not longer active,
+  another to determine which handlers are no longer active,
   which handlers are newly active, and which handlers remain
   active but have their context changed.
 
@@ -1001,6 +1001,9 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
           currentHandlerInfos.length !== matchPointResults.matchPoint) {
         finalizeTransition(transition, handlerInfos);
       }
+
+      // currentHandlerInfos was updated in finalizeTransition
+      trigger(router, router.currentHandlerInfos, true, ['didTransition']);
 
       if (router.didTransition) {
         router.didTransition(handlerInfos);

--- a/dist/router.js
+++ b/dist/router.js
@@ -806,7 +806,7 @@
     @private
 
     This function is called when transitioning from one URL to
-    another to determine which handlers are not longer active,
+    another to determine which handlers are no longer active,
     which handlers are newly active, and which handlers remain
     active but have their context changed.
 
@@ -1000,6 +1000,9 @@
             currentHandlerInfos.length !== matchPointResults.matchPoint) {
           finalizeTransition(transition, handlerInfos);
         }
+
+        // currentHandlerInfos was updated in finalizeTransition
+        trigger(router, router.currentHandlerInfos, true, ['didTransition']);
 
         if (router.didTransition) {
           router.didTransition(handlerInfos);

--- a/lib/router.js
+++ b/lib/router.js
@@ -807,7 +807,7 @@ function queryParamsEqual(a, b) {
   @private
 
   This function is called when transitioning from one URL to
-  another to determine which handlers are not longer active,
+  another to determine which handlers are no longer active,
   which handlers are newly active, and which handlers remain
   active but have their context changed.
 
@@ -1001,6 +1001,9 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
           currentHandlerInfos.length !== matchPointResults.matchPoint) {
         finalizeTransition(transition, handlerInfos);
       }
+
+      // currentHandlerInfos was updated in finalizeTransition
+      trigger(router, router.currentHandlerInfos, true, ['didTransition']);
 
       if (router.didTransition) {
         router.didTransition(handlerInfos);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2607,6 +2607,25 @@ asyncTest("transitionTo with URL transition can be called at startup", function(
   });
 });
 
+asyncTest("transitions fire a didTransition event on the destination route", function() {
+
+  expect(1);
+
+  handlers = {
+    about: {
+      events: {
+        didTransition: function() {
+          ok(true, "index's didTransition was called");
+        }
+      }
+    }
+  };
+
+  router.handleURL('/index').then(function() {
+    router.transitionTo('about').then(start, shouldNotHappen);
+  }, shouldNotHappen);
+});
+
 asyncTest("transitions can aborted in the willTransition event", function() {
 
   expect(3);


### PR DESCRIPTION
`didTransition` mirrors `willTransition`. This will provide a hook for Ember to implement a `didTransition` action on the destination route and handle breadcrumbs or analytics.
