### PR TITLE
Add support for loading substates

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -54,6 +54,11 @@ define("router",
       providedModels: null,
       resolvedModels: null,
       params: null,
+      pivotHandler: null,
+      resolveIndex: 0,
+      handlerInfos: null,
+
+      isActive: true,
 
       /**
         The Transition's internal promise. Calling `.then` on this property
@@ -97,6 +102,7 @@ define("router",
         if (this.isAborted) { return this; }
         log(this.router, this.sequence, this.targetName + ": transition was aborted");
         this.isAborted = true;
+        this.isActive = false;
         this.router.activeTransition = null;
         return this;
       },
@@ -137,6 +143,25 @@ define("router",
         return this;
       },
 
+      /**
+        Fires an event on the current list of resolved/resolving
+        handlers within this transition. Useful for firing events
+        on route hierarchies that haven't fully been entered yet.
+
+        @param {Boolean} ignoreFailure the name of the event to fire
+        @param {String} name the name of the event to fire
+       */
+      trigger: function(ignoreFailure) {
+        var args = slice.call(arguments);
+        if (typeof ignoreFailure === 'boolean') {
+          args.shift();
+        } else {
+          // Throw errors on unhandled trigger events by default
+          ignoreFailure = false;
+        }
+        trigger(this.router, this.handlerInfos.slice(0, this.resolveIndex + 1), ignoreFailure, args);
+      },
+
       toString: function() {
         return "Transition (sequence " + this.sequence + ")";
       }
@@ -145,6 +170,9 @@ define("router",
     function Router() {
       this.recognizer = new RouteRecognizer();
     }
+
+    // TODO: separate into module?
+    Router.Transition = Transition;
 
 
 
@@ -259,6 +287,10 @@ define("router",
       */
       transitionTo: function(name) {
         return doTransition(this, arguments);
+      },
+
+      intermediateTransitionTo: function(name) {
+        doTransition(this, arguments, true);
       },
 
       /**
@@ -471,7 +503,10 @@ define("router",
         throw new Error("More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler);
       }
 
-      return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+      var pivotHandlerInfo = currentHandlerInfos[matchPoint - 1],
+          pivotHandler = pivotHandlerInfo && pivotHandlerInfo.handler;
+
+      return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams, pivotHandler: pivotHandler };
     }
 
     function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
@@ -620,20 +655,20 @@ define("router",
     /**
       @private
     */
-    function createQueryParamTransition(router, queryParams) {
+    function createQueryParamTransition(router, queryParams, isIntermediate) {
       var currentHandlers = router.currentHandlerInfos,
           currentHandler = currentHandlers[currentHandlers.length - 1],
           name = currentHandler.name;
 
       log(router, "Attempting query param transition");
 
-      return createNamedTransition(router, [name, queryParams]);
+      return createNamedTransition(router, [name, queryParams], isIntermediate);
     }
 
     /**
       @private
     */
-    function createNamedTransition(router, args) {
+    function createNamedTransition(router, args, isIntermediate) {
       var partitionedArgs     = extractQueryParams(args),
         pureArgs              = partitionedArgs[0],
         queryParams           = partitionedArgs[1],
@@ -643,28 +678,46 @@ define("router",
 
       log(router, "Attempting transition to " + pureArgs[0]);
 
-      return performTransition(router, handlerInfos, slice.call(pureArgs, 1), router.currentParams, queryParams);
+      return performTransition(router,
+                               handlerInfos,
+                               slice.call(pureArgs, 1),
+                               router.currentParams,
+                               queryParams,
+                               null,
+                               isIntermediate);
     }
 
     /**
       @private
     */
-    function createURLTransition(router, url) {
+    function createURLTransition(router, url, isIntermediate) {
       var results = router.recognizer.recognize(url),
           currentHandlerInfos = router.currentHandlerInfos,
-          queryParams = {};
+          queryParams = {},
+          i, len;
 
       log(router, "Attempting URL transition to " + url);
+
+      if (results) {
+        // Make sure this route is actually accessible by URL.
+        for (i = 0, len = results.length; i < len; ++i) {
+
+          if (router.getHandler(results[i].handler).inaccessiblyByURL) {
+            results = null;
+            break;
+          }
+        }
+      }
 
       if (!results) {
         return errorTransition(router, new Router.UnrecognizedURLError(url));
       }
 
-      for(var i = 0; i < results.length; i++) {
+      for(i = 0, len = results.length; i < len; i++) {
         merge(queryParams, results[i].queryParams);
       }
 
-      return performTransition(router, results, [], {}, queryParams);
+      return performTransition(router, results, [], {}, queryParams, null, isIntermediate);
     }
 
 
@@ -755,7 +808,7 @@ define("router",
       } catch(e) {
         if (!(e instanceof Router.TransitionAborted)) {
           // Trigger the `error` event starting from this failed handler.
-          trigger(transition.router, currentHandlerInfos.concat(handlerInfo), true, ['error', e, transition]);
+          transition.trigger(true, 'error', e, transition, handler);
         }
 
         // Propagate the error so that the transition promise will reject.
@@ -944,17 +997,37 @@ define("router",
       }
     }
 
+    function performIntermediateTransition(router, recogHandlers, matchPointResults) {
+
+      var handlerInfos = generateHandlerInfos(router, recogHandlers);
+      for (var i = 0; i < handlerInfos.length; ++i) {
+        var handlerInfo = handlerInfos[i];
+        handlerInfo.context = matchPointResults.providedModels[handlerInfo.name];
+      }
+
+      var stubbedTransition = {
+        router: router,
+        isAborted: false
+      };
+
+      setupContexts(stubbedTransition, handlerInfos);
+    }
+
     /**
       @private
 
       Creates, begins, and returns a Transition.
      */
-    function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data) {
+    function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data, isIntermediate) {
 
       var matchPointResults = getMatchPoint(router, recogHandlers, providedModelsArray, params, queryParams),
           targetName = recogHandlers[recogHandlers.length - 1].handler,
           wasTransitioning = false,
           currentHandlerInfos = router.currentHandlerInfos;
+
+      if (isIntermediate) {
+        return performIntermediateTransition(router, recogHandlers, matchPointResults);
+      }
 
       // Check if there's already a transition underway.
       if (router.activeTransition) {
@@ -974,9 +1047,11 @@ define("router",
       transition.params = matchPointResults.params;
       transition.data = data || {};
       transition.queryParams = queryParams;
+      transition.pivotHandler = matchPointResults.pivotHandler;
       router.activeTransition = transition;
 
       var handlerInfos = generateHandlerInfos(router, recogHandlers);
+      transition.handlerInfos = handlerInfos;
 
       // Fire 'willTransition' event on current handlers, but don't fire it
       // if a transition was already underway.
@@ -985,7 +1060,7 @@ define("router",
       }
 
       log(router, transition.sequence, "Beginning validation for transition to " + transition.targetName);
-      validateEntry(transition, handlerInfos, 0, matchPointResults.matchPoint, matchPointResults.handlerParams)
+      validateEntry(transition, matchPointResults.matchPoint, matchPointResults.handlerParams)
                    .then(transitionSuccess, transitionFailure);
 
       return transition;
@@ -1013,6 +1088,7 @@ define("router",
           log(router, transition.sequence, "TRANSITION COMPLETE.");
 
           // Resolve with the final handler.
+          transition.isActive = false;
           deferred.resolve(handlerInfos[handlerInfos.length - 1].handler);
         } catch(e) {
           deferred.reject(e);
@@ -1042,7 +1118,6 @@ define("router",
       for (var i = 0, len = recogHandlers.length; i < len; ++i) {
         var handlerObj = recogHandlers[i],
             isDynamic = handlerObj.isDynamic || (handlerObj.names && handlerObj.names.length);
-
 
         var handlerInfo = {
           isDynamic: !!isDynamic,
@@ -1089,6 +1164,7 @@ define("router",
       var router = transition.router,
           seq = transition.sequence,
           handlerName = handlerInfos[handlerInfos.length - 1].name,
+          urlMethod = transition.urlMethod,
           i;
 
       // Collect params for URL.
@@ -1098,6 +1174,10 @@ define("router",
         if (handlerInfo.isDynamic) {
           var providedModel = providedModels.pop();
           objects.unshift(isParam(providedModel) ? providedModel.toString() : handlerInfo.context);
+        }
+
+        if (handlerInfo.handler.inaccessiblyByURL) {
+          urlMethod = null;
         }
       }
 
@@ -1112,8 +1192,6 @@ define("router",
 
       router.currentParams = params;
 
-
-      var urlMethod = transition.urlMethod;
       if (urlMethod) {
         var url = router.recognizer.generate(handlerName, params);
 
@@ -1136,7 +1214,10 @@ define("router",
       and `afterModel` in promises, and checks for redirects/aborts
       between each.
      */
-    function validateEntry(transition, handlerInfos, index, matchPoint, handlerParams) {
+    function validateEntry(transition, matchPoint, handlerParams) {
+
+      var handlerInfos = transition.handlerInfos,
+          index = transition.resolveIndex;
 
       if (index === handlerInfos.length) {
         // No more contexts to resolve.
@@ -1159,6 +1240,8 @@ define("router",
           handlerInfo.handler.context;
         return proceed();
       }
+
+      transition.trigger(true, 'willResolveModel', transition, handler);
 
       return RSVP.resolve().then(handleAbort)
                            .then(beforeModel)
@@ -1193,7 +1276,7 @@ define("router",
 
         // An error was thrown / promise rejected, so fire an
         // `error` event from this handler info up to root.
-        trigger(router, handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
+        transition.trigger(true, 'error', reason, transition, handlerInfo.handler);
 
         // Propagate the original error.
         return RSVP.reject(reason);
@@ -1247,7 +1330,8 @@ define("router",
         log(router, seq, handlerName + ": validation succeeded, proceeding");
 
         handlerInfo.context = transition.resolvedModels[handlerInfo.name];
-        return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
+        transition.resolveIndex++;
+        return validateEntry(transition, matchPoint, handlerParams);
       }
     }
 
@@ -1317,16 +1401,16 @@ define("router",
       @param {Array[Object]} args arguments passed to transitionTo,
         replaceWith, or handleURL
     */
-    function doTransition(router, args) {
+    function doTransition(router, args, isIntermediate) {
       // Normalize blank transitions to root URL transitions.
       var name = args[0] || '/';
 
       if(args.length === 1 && args[0].hasOwnProperty('queryParams')) {
-        return createQueryParamTransition(router, args[0]);
+        return createQueryParamTransition(router, args[0], isIntermediate);
       } else if (name.charAt(0) === '/') {
-        return createURLTransition(router, name);
+        return createURLTransition(router, name, isIntermediate);
       } else {
-        return createNamedTransition(router, slice.call(args));
+        return createNamedTransition(router, slice.call(args), isIntermediate);
       }
     }
 

--- a/dist/router.cjs.js
+++ b/dist/router.cjs.js
@@ -53,6 +53,11 @@ Transition.prototype = {
   providedModels: null,
   resolvedModels: null,
   params: null,
+  pivotHandler: null,
+  resolveIndex: 0,
+  handlerInfos: null,
+
+  isActive: true,
 
   /**
     The Transition's internal promise. Calling `.then` on this property
@@ -96,6 +101,7 @@ Transition.prototype = {
     if (this.isAborted) { return this; }
     log(this.router, this.sequence, this.targetName + ": transition was aborted");
     this.isAborted = true;
+    this.isActive = false;
     this.router.activeTransition = null;
     return this;
   },
@@ -136,6 +142,25 @@ Transition.prototype = {
     return this;
   },
 
+  /**
+    Fires an event on the current list of resolved/resolving
+    handlers within this transition. Useful for firing events
+    on route hierarchies that haven't fully been entered yet.
+
+    @param {Boolean} ignoreFailure the name of the event to fire
+    @param {String} name the name of the event to fire
+   */
+  trigger: function(ignoreFailure) {
+    var args = slice.call(arguments);
+    if (typeof ignoreFailure === 'boolean') {
+      args.shift();
+    } else {
+      // Throw errors on unhandled trigger events by default
+      ignoreFailure = false;
+    }
+    trigger(this.router, this.handlerInfos.slice(0, this.resolveIndex + 1), ignoreFailure, args);
+  },
+
   toString: function() {
     return "Transition (sequence " + this.sequence + ")";
   }
@@ -144,6 +169,9 @@ Transition.prototype = {
 function Router() {
   this.recognizer = new RouteRecognizer();
 }
+
+// TODO: separate into module?
+Router.Transition = Transition;
 
 
 
@@ -258,6 +286,10 @@ Router.prototype = {
   */
   transitionTo: function(name) {
     return doTransition(this, arguments);
+  },
+
+  intermediateTransitionTo: function(name) {
+    doTransition(this, arguments, true);
   },
 
   /**
@@ -470,7 +502,10 @@ function getMatchPoint(router, handlers, objects, inputParams, queryParams) {
     throw new Error("More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler);
   }
 
-  return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+  var pivotHandlerInfo = currentHandlerInfos[matchPoint - 1],
+      pivotHandler = pivotHandlerInfo && pivotHandlerInfo.handler;
+
+  return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams, pivotHandler: pivotHandler };
 }
 
 function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
@@ -619,20 +654,20 @@ function generateHandlerInfosWithQueryParams(router, handlers, queryParams) {
 /**
   @private
 */
-function createQueryParamTransition(router, queryParams) {
+function createQueryParamTransition(router, queryParams, isIntermediate) {
   var currentHandlers = router.currentHandlerInfos,
       currentHandler = currentHandlers[currentHandlers.length - 1],
       name = currentHandler.name;
 
   log(router, "Attempting query param transition");
 
-  return createNamedTransition(router, [name, queryParams]);
+  return createNamedTransition(router, [name, queryParams], isIntermediate);
 }
 
 /**
   @private
 */
-function createNamedTransition(router, args) {
+function createNamedTransition(router, args, isIntermediate) {
   var partitionedArgs     = extractQueryParams(args),
     pureArgs              = partitionedArgs[0],
     queryParams           = partitionedArgs[1],
@@ -642,28 +677,46 @@ function createNamedTransition(router, args) {
 
   log(router, "Attempting transition to " + pureArgs[0]);
 
-  return performTransition(router, handlerInfos, slice.call(pureArgs, 1), router.currentParams, queryParams);
+  return performTransition(router,
+                           handlerInfos,
+                           slice.call(pureArgs, 1),
+                           router.currentParams,
+                           queryParams,
+                           null,
+                           isIntermediate);
 }
 
 /**
   @private
 */
-function createURLTransition(router, url) {
+function createURLTransition(router, url, isIntermediate) {
   var results = router.recognizer.recognize(url),
       currentHandlerInfos = router.currentHandlerInfos,
-      queryParams = {};
+      queryParams = {},
+      i, len;
 
   log(router, "Attempting URL transition to " + url);
+
+  if (results) {
+    // Make sure this route is actually accessible by URL.
+    for (i = 0, len = results.length; i < len; ++i) {
+
+      if (router.getHandler(results[i].handler).inaccessiblyByURL) {
+        results = null;
+        break;
+      }
+    }
+  }
 
   if (!results) {
     return errorTransition(router, new Router.UnrecognizedURLError(url));
   }
 
-  for(var i = 0; i < results.length; i++) {
+  for(i = 0, len = results.length; i < len; i++) {
     merge(queryParams, results[i].queryParams);
   }
 
-  return performTransition(router, results, [], {}, queryParams);
+  return performTransition(router, results, [], {}, queryParams, null, isIntermediate);
 }
 
 
@@ -754,7 +807,7 @@ function handlerEnteredOrUpdated(transition, currentHandlerInfos, handlerInfo, e
   } catch(e) {
     if (!(e instanceof Router.TransitionAborted)) {
       // Trigger the `error` event starting from this failed handler.
-      trigger(transition.router, currentHandlerInfos.concat(handlerInfo), true, ['error', e, transition]);
+      transition.trigger(true, 'error', e, transition, handler);
     }
 
     // Propagate the error so that the transition promise will reject.
@@ -943,17 +996,37 @@ function extractQueryParams(array) {
   }
 }
 
+function performIntermediateTransition(router, recogHandlers, matchPointResults) {
+
+  var handlerInfos = generateHandlerInfos(router, recogHandlers);
+  for (var i = 0; i < handlerInfos.length; ++i) {
+    var handlerInfo = handlerInfos[i];
+    handlerInfo.context = matchPointResults.providedModels[handlerInfo.name];
+  }
+
+  var stubbedTransition = {
+    router: router,
+    isAborted: false
+  };
+
+  setupContexts(stubbedTransition, handlerInfos);
+}
+
 /**
   @private
 
   Creates, begins, and returns a Transition.
  */
-function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data) {
+function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data, isIntermediate) {
 
   var matchPointResults = getMatchPoint(router, recogHandlers, providedModelsArray, params, queryParams),
       targetName = recogHandlers[recogHandlers.length - 1].handler,
       wasTransitioning = false,
       currentHandlerInfos = router.currentHandlerInfos;
+
+  if (isIntermediate) {
+    return performIntermediateTransition(router, recogHandlers, matchPointResults);
+  }
 
   // Check if there's already a transition underway.
   if (router.activeTransition) {
@@ -973,9 +1046,11 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
   transition.params = matchPointResults.params;
   transition.data = data || {};
   transition.queryParams = queryParams;
+  transition.pivotHandler = matchPointResults.pivotHandler;
   router.activeTransition = transition;
 
   var handlerInfos = generateHandlerInfos(router, recogHandlers);
+  transition.handlerInfos = handlerInfos;
 
   // Fire 'willTransition' event on current handlers, but don't fire it
   // if a transition was already underway.
@@ -984,7 +1059,7 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
   }
 
   log(router, transition.sequence, "Beginning validation for transition to " + transition.targetName);
-  validateEntry(transition, handlerInfos, 0, matchPointResults.matchPoint, matchPointResults.handlerParams)
+  validateEntry(transition, matchPointResults.matchPoint, matchPointResults.handlerParams)
                .then(transitionSuccess, transitionFailure);
 
   return transition;
@@ -1012,6 +1087,7 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
       log(router, transition.sequence, "TRANSITION COMPLETE.");
 
       // Resolve with the final handler.
+      transition.isActive = false;
       deferred.resolve(handlerInfos[handlerInfos.length - 1].handler);
     } catch(e) {
       deferred.reject(e);
@@ -1041,7 +1117,6 @@ function generateHandlerInfos(router, recogHandlers) {
   for (var i = 0, len = recogHandlers.length; i < len; ++i) {
     var handlerObj = recogHandlers[i],
         isDynamic = handlerObj.isDynamic || (handlerObj.names && handlerObj.names.length);
-
 
     var handlerInfo = {
       isDynamic: !!isDynamic,
@@ -1088,6 +1163,7 @@ function finalizeTransition(transition, handlerInfos) {
   var router = transition.router,
       seq = transition.sequence,
       handlerName = handlerInfos[handlerInfos.length - 1].name,
+      urlMethod = transition.urlMethod,
       i;
 
   // Collect params for URL.
@@ -1097,6 +1173,10 @@ function finalizeTransition(transition, handlerInfos) {
     if (handlerInfo.isDynamic) {
       var providedModel = providedModels.pop();
       objects.unshift(isParam(providedModel) ? providedModel.toString() : handlerInfo.context);
+    }
+
+    if (handlerInfo.handler.inaccessiblyByURL) {
+      urlMethod = null;
     }
   }
 
@@ -1111,8 +1191,6 @@ function finalizeTransition(transition, handlerInfos) {
 
   router.currentParams = params;
 
-
-  var urlMethod = transition.urlMethod;
   if (urlMethod) {
     var url = router.recognizer.generate(handlerName, params);
 
@@ -1135,7 +1213,10 @@ function finalizeTransition(transition, handlerInfos) {
   and `afterModel` in promises, and checks for redirects/aborts
   between each.
  */
-function validateEntry(transition, handlerInfos, index, matchPoint, handlerParams) {
+function validateEntry(transition, matchPoint, handlerParams) {
+
+  var handlerInfos = transition.handlerInfos,
+      index = transition.resolveIndex;
 
   if (index === handlerInfos.length) {
     // No more contexts to resolve.
@@ -1158,6 +1239,8 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
       handlerInfo.handler.context;
     return proceed();
   }
+
+  transition.trigger(true, 'willResolveModel', transition, handler);
 
   return RSVP.resolve().then(handleAbort)
                        .then(beforeModel)
@@ -1192,7 +1275,7 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
 
     // An error was thrown / promise rejected, so fire an
     // `error` event from this handler info up to root.
-    trigger(router, handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
+    transition.trigger(true, 'error', reason, transition, handlerInfo.handler);
 
     // Propagate the original error.
     return RSVP.reject(reason);
@@ -1246,7 +1329,8 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     log(router, seq, handlerName + ": validation succeeded, proceeding");
 
     handlerInfo.context = transition.resolvedModels[handlerInfo.name];
-    return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
+    transition.resolveIndex++;
+    return validateEntry(transition, matchPoint, handlerParams);
   }
 }
 
@@ -1316,16 +1400,16 @@ function log(router, sequence, msg) {
   @param {Array[Object]} args arguments passed to transitionTo,
     replaceWith, or handleURL
 */
-function doTransition(router, args) {
+function doTransition(router, args, isIntermediate) {
   // Normalize blank transitions to root URL transitions.
   var name = args[0] || '/';
 
   if(args.length === 1 && args[0].hasOwnProperty('queryParams')) {
-    return createQueryParamTransition(router, args[0]);
+    return createQueryParamTransition(router, args[0], isIntermediate);
   } else if (name.charAt(0) === '/') {
-    return createURLTransition(router, name);
+    return createURLTransition(router, name, isIntermediate);
   } else {
-    return createNamedTransition(router, slice.call(args));
+    return createNamedTransition(router, slice.call(args), isIntermediate);
   }
 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -52,6 +52,11 @@ Transition.prototype = {
   providedModels: null,
   resolvedModels: null,
   params: null,
+  pivotHandler: null,
+  resolveIndex: 0,
+  handlerInfos: null,
+
+  isActive: true,
 
   /**
     The Transition's internal promise. Calling `.then` on this property
@@ -95,6 +100,7 @@ Transition.prototype = {
     if (this.isAborted) { return this; }
     log(this.router, this.sequence, this.targetName + ": transition was aborted");
     this.isAborted = true;
+    this.isActive = false;
     this.router.activeTransition = null;
     return this;
   },
@@ -135,6 +141,25 @@ Transition.prototype = {
     return this;
   },
 
+  /**
+    Fires an event on the current list of resolved/resolving
+    handlers within this transition. Useful for firing events
+    on route hierarchies that haven't fully been entered yet.
+
+    @param {Boolean} ignoreFailure the name of the event to fire
+    @param {String} name the name of the event to fire
+   */
+  trigger: function(ignoreFailure) {
+    var args = slice.call(arguments);
+    if (typeof ignoreFailure === 'boolean') {
+      args.shift();
+    } else {
+      // Throw errors on unhandled trigger events by default
+      ignoreFailure = false;
+    }
+    trigger(this.router, this.handlerInfos.slice(0, this.resolveIndex + 1), ignoreFailure, args);
+  },
+
   toString: function() {
     return "Transition (sequence " + this.sequence + ")";
   }
@@ -143,6 +168,9 @@ Transition.prototype = {
 function Router() {
   this.recognizer = new RouteRecognizer();
 }
+
+// TODO: separate into module?
+Router.Transition = Transition;
 
 export default Router;
 
@@ -258,6 +286,10 @@ Router.prototype = {
   */
   transitionTo: function(name) {
     return doTransition(this, arguments);
+  },
+
+  intermediateTransitionTo: function(name) {
+    doTransition(this, arguments, true);
   },
 
   /**
@@ -470,7 +502,10 @@ function getMatchPoint(router, handlers, objects, inputParams, queryParams) {
     throw new Error("More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler);
   }
 
-  return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+  var pivotHandlerInfo = currentHandlerInfos[matchPoint - 1],
+      pivotHandler = pivotHandlerInfo && pivotHandlerInfo.handler;
+
+  return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams, pivotHandler: pivotHandler };
 }
 
 function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
@@ -619,20 +654,20 @@ function generateHandlerInfosWithQueryParams(router, handlers, queryParams) {
 /**
   @private
 */
-function createQueryParamTransition(router, queryParams) {
+function createQueryParamTransition(router, queryParams, isIntermediate) {
   var currentHandlers = router.currentHandlerInfos,
       currentHandler = currentHandlers[currentHandlers.length - 1],
       name = currentHandler.name;
 
   log(router, "Attempting query param transition");
 
-  return createNamedTransition(router, [name, queryParams]);
+  return createNamedTransition(router, [name, queryParams], isIntermediate);
 }
 
 /**
   @private
 */
-function createNamedTransition(router, args) {
+function createNamedTransition(router, args, isIntermediate) {
   var partitionedArgs     = extractQueryParams(args),
     pureArgs              = partitionedArgs[0],
     queryParams           = partitionedArgs[1],
@@ -642,28 +677,46 @@ function createNamedTransition(router, args) {
 
   log(router, "Attempting transition to " + pureArgs[0]);
 
-  return performTransition(router, handlerInfos, slice.call(pureArgs, 1), router.currentParams, queryParams);
+  return performTransition(router,
+                           handlerInfos,
+                           slice.call(pureArgs, 1),
+                           router.currentParams,
+                           queryParams,
+                           null,
+                           isIntermediate);
 }
 
 /**
   @private
 */
-function createURLTransition(router, url) {
+function createURLTransition(router, url, isIntermediate) {
   var results = router.recognizer.recognize(url),
       currentHandlerInfos = router.currentHandlerInfos,
-      queryParams = {};
+      queryParams = {},
+      i, len;
 
   log(router, "Attempting URL transition to " + url);
+
+  if (results) {
+    // Make sure this route is actually accessible by URL.
+    for (i = 0, len = results.length; i < len; ++i) {
+
+      if (router.getHandler(results[i].handler).inaccessiblyByURL) {
+        results = null;
+        break;
+      }
+    }
+  }
 
   if (!results) {
     return errorTransition(router, new Router.UnrecognizedURLError(url));
   }
 
-  for(var i = 0; i < results.length; i++) {
+  for(i = 0, len = results.length; i < len; i++) {
     merge(queryParams, results[i].queryParams);
   }
 
-  return performTransition(router, results, [], {}, queryParams);
+  return performTransition(router, results, [], {}, queryParams, null, isIntermediate);
 }
 
 
@@ -754,7 +807,7 @@ function handlerEnteredOrUpdated(transition, currentHandlerInfos, handlerInfo, e
   } catch(e) {
     if (!(e instanceof Router.TransitionAborted)) {
       // Trigger the `error` event starting from this failed handler.
-      trigger(transition.router, currentHandlerInfos.concat(handlerInfo), true, ['error', e, transition]);
+      transition.trigger(true, 'error', e, transition, handler);
     }
 
     // Propagate the error so that the transition promise will reject.
@@ -943,17 +996,37 @@ function extractQueryParams(array) {
   }
 }
 
+function performIntermediateTransition(router, recogHandlers, matchPointResults) {
+
+  var handlerInfos = generateHandlerInfos(router, recogHandlers);
+  for (var i = 0; i < handlerInfos.length; ++i) {
+    var handlerInfo = handlerInfos[i];
+    handlerInfo.context = matchPointResults.providedModels[handlerInfo.name];
+  }
+
+  var stubbedTransition = {
+    router: router,
+    isAborted: false
+  };
+
+  setupContexts(stubbedTransition, handlerInfos);
+}
+
 /**
   @private
 
   Creates, begins, and returns a Transition.
  */
-function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data) {
+function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data, isIntermediate) {
 
   var matchPointResults = getMatchPoint(router, recogHandlers, providedModelsArray, params, queryParams),
       targetName = recogHandlers[recogHandlers.length - 1].handler,
       wasTransitioning = false,
       currentHandlerInfos = router.currentHandlerInfos;
+
+  if (isIntermediate) {
+    return performIntermediateTransition(router, recogHandlers, matchPointResults);
+  }
 
   // Check if there's already a transition underway.
   if (router.activeTransition) {
@@ -973,9 +1046,11 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
   transition.params = matchPointResults.params;
   transition.data = data || {};
   transition.queryParams = queryParams;
+  transition.pivotHandler = matchPointResults.pivotHandler;
   router.activeTransition = transition;
 
   var handlerInfos = generateHandlerInfos(router, recogHandlers);
+  transition.handlerInfos = handlerInfos;
 
   // Fire 'willTransition' event on current handlers, but don't fire it
   // if a transition was already underway.
@@ -984,7 +1059,7 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
   }
 
   log(router, transition.sequence, "Beginning validation for transition to " + transition.targetName);
-  validateEntry(transition, handlerInfos, 0, matchPointResults.matchPoint, matchPointResults.handlerParams)
+  validateEntry(transition, matchPointResults.matchPoint, matchPointResults.handlerParams)
                .then(transitionSuccess, transitionFailure);
 
   return transition;
@@ -1012,6 +1087,7 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
       log(router, transition.sequence, "TRANSITION COMPLETE.");
 
       // Resolve with the final handler.
+      transition.isActive = false;
       deferred.resolve(handlerInfos[handlerInfos.length - 1].handler);
     } catch(e) {
       deferred.reject(e);
@@ -1041,7 +1117,6 @@ function generateHandlerInfos(router, recogHandlers) {
   for (var i = 0, len = recogHandlers.length; i < len; ++i) {
     var handlerObj = recogHandlers[i],
         isDynamic = handlerObj.isDynamic || (handlerObj.names && handlerObj.names.length);
-
 
     var handlerInfo = {
       isDynamic: !!isDynamic,
@@ -1088,6 +1163,7 @@ function finalizeTransition(transition, handlerInfos) {
   var router = transition.router,
       seq = transition.sequence,
       handlerName = handlerInfos[handlerInfos.length - 1].name,
+      urlMethod = transition.urlMethod,
       i;
 
   // Collect params for URL.
@@ -1097,6 +1173,10 @@ function finalizeTransition(transition, handlerInfos) {
     if (handlerInfo.isDynamic) {
       var providedModel = providedModels.pop();
       objects.unshift(isParam(providedModel) ? providedModel.toString() : handlerInfo.context);
+    }
+
+    if (handlerInfo.handler.inaccessiblyByURL) {
+      urlMethod = null;
     }
   }
 
@@ -1111,8 +1191,6 @@ function finalizeTransition(transition, handlerInfos) {
 
   router.currentParams = params;
 
-
-  var urlMethod = transition.urlMethod;
   if (urlMethod) {
     var url = router.recognizer.generate(handlerName, params);
 
@@ -1135,7 +1213,10 @@ function finalizeTransition(transition, handlerInfos) {
   and `afterModel` in promises, and checks for redirects/aborts
   between each.
  */
-function validateEntry(transition, handlerInfos, index, matchPoint, handlerParams) {
+function validateEntry(transition, matchPoint, handlerParams) {
+
+  var handlerInfos = transition.handlerInfos,
+      index = transition.resolveIndex;
 
   if (index === handlerInfos.length) {
     // No more contexts to resolve.
@@ -1158,6 +1239,8 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
       handlerInfo.handler.context;
     return proceed();
   }
+
+  transition.trigger(true, 'willResolveModel', transition, handler);
 
   return RSVP.resolve().then(handleAbort)
                        .then(beforeModel)
@@ -1192,7 +1275,7 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
 
     // An error was thrown / promise rejected, so fire an
     // `error` event from this handler info up to root.
-    trigger(router, handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
+    transition.trigger(true, 'error', reason, transition, handlerInfo.handler);
 
     // Propagate the original error.
     return RSVP.reject(reason);
@@ -1246,7 +1329,8 @@ function validateEntry(transition, handlerInfos, index, matchPoint, handlerParam
     log(router, seq, handlerName + ": validation succeeded, proceeding");
 
     handlerInfo.context = transition.resolvedModels[handlerInfo.name];
-    return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
+    transition.resolveIndex++;
+    return validateEntry(transition, matchPoint, handlerParams);
   }
 }
 
@@ -1316,16 +1400,16 @@ function log(router, sequence, msg) {
   @param {Array[Object]} args arguments passed to transitionTo,
     replaceWith, or handleURL
 */
-function doTransition(router, args) {
+function doTransition(router, args, isIntermediate) {
   // Normalize blank transitions to root URL transitions.
   var name = args[0] || '/';
 
   if(args.length === 1 && args[0].hasOwnProperty('queryParams')) {
-    return createQueryParamTransition(router, args[0]);
+    return createQueryParamTransition(router, args[0], isIntermediate);
   } else if (name.charAt(0) === '/') {
-    return createURLTransition(router, name);
+    return createURLTransition(router, name, isIntermediate);
   } else {
-    return createNamedTransition(router, slice.call(args));
+    return createNamedTransition(router, slice.call(args), isIntermediate);
   }
 }
 


### PR DESCRIPTION
See: https://github.com/emberjs/ember.js/pull/3568
- added the concept of an intermediate transition which happens immediately and doesn't cancel an existing active transition
- the "pivot handler" of a transition is provided on the Transition object
- added `inaccessibleByURL` as a handler property that will prevent URL transitions into this route, as well as prevent URL updates when `transitionTo`ing into this route. This ended up not being strictly necessary to the loading substate stuff, so maybe i should take it out?
- `getHandler` is now passed the name of the handler's parent route as a second param for those libs that don't plan on reusing the same handler instance between different routes. Looking at you, Ember.
- added `willResolveModel` event that fires when a destination route's `model` hooks are about to be called.
