### PR TITLE
Enforce v0.3.2 of module transpiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/tildeio/router.js.git"
+  },
+  "devDependencies": {
+    "es6-module-transpiler": "~0.3.2"
   }
 }

--- a/tasks/support/js_module_transpiler.rb
+++ b/tasks/support/js_module_transpiler.rb
@@ -59,7 +59,7 @@ module JsModuleTranspiler
 
     def ensure_es6_transpiler_package_installed
       return if File.executable?(es6_transpiler_binary)
-      %x{npm install es6-module-transpiler}
+      %x{npm install}
     end
 
     def es6_transpiler_binary


### PR DESCRIPTION
es6-module-transpiler 0.3.2 does not produce output compatible with 0.2.x 
consumers because it now supports mixing named & default exports.

For 0aa5998715657f452a047f1c357c614ebe01b09b and later users will need to
`var Router = requireModule("Router")['default']` rather  than the 0.2.x style
`requireModule("Router")`.  Users using es6-module-transpiler simply need to 
upgrade their transpiler.
- see https://github.com/square/es6-module-transpiler#default-exports-1
