### PR TITLE
Fix build for RSVP 2.x.

### DIFF
--- a/dist/router.amd.js
+++ b/dist/router.amd.js
@@ -21,7 +21,7 @@ define("router",
     */
 
     var RouteRecognizer = __dependency1__['default'];
-    var RSVP = __dependency2__['default'];
+    var RSVP = __dependency2__;
 
     var slice = Array.prototype.slice;
 


### PR DESCRIPTION
RSVP 2.x uses 0.2.x style transpilation.  There is a post-process build-step
to make `router.amd.js` work with RSVP 2.x.  It should be removed when RSVP
3.x is released with 0.3.x style transpilation.
