### PR TITLE
Label all promises for debugging

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -88,8 +88,8 @@ Transition.prototype = {
     @param {Function} success
     @param {Function} failure
    */
-  then: function(success, failure) {
-    return this.promise.then(success, failure);
+  then: function(success, failure, label) {
+    return this.promise.then(success, failure, label);
   },
 
   /**
@@ -1037,7 +1037,7 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
     wasTransitioning = true;
   }
 
-  var deferred = RSVP.defer(),
+  var deferred = RSVP.defer(promiseLabel("Transition to '" + targetName + "'")),
       transition = new Transition(router, deferred.promise);
 
   transition.targetName = targetName;
@@ -1060,7 +1060,7 @@ function performTransition(router, recogHandlers, providedModelsArray, params, q
 
   log(router, transition.sequence, "Beginning validation for transition to " + transition.targetName);
   validateEntry(transition, matchPointResults.matchPoint, matchPointResults.handlerParams)
-               .then(transitionSuccess, transitionFailure);
+               .then(transitionSuccess, transitionFailure, promiseLabel("Handle transition success / failure"));
 
   return transition;
 
@@ -1215,7 +1215,7 @@ function validateEntry(transition, matchPoint, handlerParams) {
 
   if (index === handlerInfos.length) {
     // No more contexts to resolve.
-    return RSVP.resolve(transition.resolvedModels);
+    return RSVP.resolve(transition.resolvedModels, promiseLabel("Transition '" + transition.targetName + "' handlers complete"));
   }
 
   var router = transition.router,
@@ -1237,20 +1237,20 @@ function validateEntry(transition, matchPoint, handlerParams) {
 
   transition.trigger(true, 'willResolveModel', transition, handler);
 
-  return RSVP.resolve().then(handleAbort)
-                       .then(beforeModel)
-                       .then(handleAbort)
-                       .then(model)
-                       .then(handleAbort)
-                       .then(afterModel)
-                       .then(handleAbort)
-                       .then(null, handleError)
-                       .then(proceed);
+  return RSVP.resolve(undefined, promiseLabel("Start route '" + handlerName + "'")).then(handleAbort, null, promiseLabel("Handle abort"))
+                       .then(beforeModel, null, promiseLabel("Before model"))
+                       .then(handleAbort, null, promiseLabel("Handle abort"))
+                       .then(model, null, promiseLabel("Model"))
+                       .then(handleAbort, null, promiseLabel("Handle abort"))
+                       .then(afterModel, null, promiseLabel("After model"))
+                       .then(handleAbort, null, promiseLabel("Handle abort"))
+                       .then(null, handleError, promiseLabel("Handle error"))
+                       .then(proceed, null, promiseLabel("Proceed to next handler"));
 
   function handleAbort(result) {
     if (transition.isAborted) {
       log(transition.router, transition.sequence, "detected abort.");
-      return RSVP.reject(new Router.TransitionAborted());
+      return RSVP.reject(new Router.TransitionAborted(), promiseLabel("Transition aborted"));
     }
 
     return result;
@@ -1260,7 +1260,7 @@ function validateEntry(transition, matchPoint, handlerParams) {
     if (reason instanceof Router.TransitionAborted || transition.isAborted) {
       // if the transition was aborted and *no additional* error was thrown,
       // reject with the Router.TransitionAborted instance
-      return RSVP.reject(reason);
+      return RSVP.reject(reason, promiseLabel("Transition aborted"));
     }
 
     // otherwise, we're here because of a different error
@@ -1273,7 +1273,7 @@ function validateEntry(transition, matchPoint, handlerParams) {
     transition.trigger(true, 'error', reason, transition, handlerInfo.handler);
 
     // Propagate the original error.
-    return RSVP.reject(reason);
+    return RSVP.reject(reason, promiseLabel("Transition error"));
   }
 
   function beforeModel() {
@@ -1445,3 +1445,12 @@ function serialize(handler, model, names) {
   return object;
 }
 
+/**
+  @private
+
+  Wraps a promise label with
+  library specific identifier
+*/
+function promiseLabel(text) {
+  return "Router: " + text;
+}


### PR DESCRIPTION
Preparation for the Ember Inspector's promise tab (see https://github.com/tildeio/ember-extension/pull/76).  This is backwards compatible.

**Not ready to be merged yet (waiting for the [rsvp inspection branch](https://github.com/stefanpenner/rsvp.js/tree/inspection) to be merged into master)**.
