### PR TITLE
Prevent exception when checking isActive on an intermediate route

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -402,7 +402,7 @@ Router.prototype = {
 
           if (isParam(object)) {
             var name = recogHandler.names[0];
-            if ("" + object !== this.currentParams[name]) { return false; }
+            if (!this.currentParams || "" + object !== this.currentParams[name]) { return false; }
           } else if (handlerInfo.context !== object) {
             return false;
           }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -196,6 +196,12 @@ asyncTest("isActive respects query params", function() {
   }, shouldNotHappen);
 });
 
+test("isActive should not break on initial intermediate route", function() {
+  expect(1);
+  router.intermediateTransitionTo("/posts/admin/1/posts");
+  ok(!router.isActive('admin', '1'), 'should not be active yet');
+});
+
 asyncTest("when transitioning with the same context, setup should only be called once", function() {
   var parentSetupCount = 0,
       childSetupCount = 0;


### PR DESCRIPTION
This addresses https://github.com/emberjs/ember.js/issues/3810

The router's `isActive` expects `currentParams` to always be available, but that's not true if the first route we render is an intermediate transition.
