### PR TITLE
[QueryParams] support for isActive

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -277,8 +277,7 @@ Router.prototype = {
     var partitionedArgs   = extractQueryParams(slice.call(arguments, 1)),
         contexts          = partitionedArgs[0],
         queryParams       = partitionedArgs[1],
-        activeQueryParams  = {},
-        effectiveQueryParams = {};
+        activeQueryParams  = this.state.queryParams;
 
     var targetHandlerInfos = this.state.handlerInfos,
         found = false, names, object, handlerInfo, handlerObj, i, len;
@@ -310,7 +309,8 @@ Router.prototype = {
 
     var newState = intent.applyToHandlers(state, recogHandlers, this.getHandler, targetHandler, true, true);
 
-    return handlerInfosEqual(newState.handlerInfos, state.handlerInfos);
+    return handlerInfosEqual(newState.handlerInfos, state.handlerInfos) && 
+           !getChangelist(activeQueryParams, queryParams);
   },
 
   trigger: function(name) {

--- a/test/tests/query_params_test.js
+++ b/test/tests/query_params_test.js
@@ -341,3 +341,23 @@ test("can retry a query-params refresh", function() {
   expectedUrl = '/index?foo=def';
 });
 
+test("tests whether query params to transitionTo are considered active", function() {
+  expect(5);
+
+  handlers.index = {
+    events: {
+      finalizeQueryParamChange: function(params, finalParams) {
+        finalParams.push({ key: 'foo', value: params.foo });
+        finalParams.push({ key: 'bar', value: params.bar });
+      }
+    }
+  };
+
+  transitionTo(router, '/index?foo=8&bar=9');
+  deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
+  ok(router.isActive('index', { queryParams: {foo: '8', bar: '9' }}), "The index handler is active");
+  ok(!router.isActive('index', { queryParams: {foo: '8'}}), "Only supply one changed query param");
+  ok(!router.isActive('index', { queryParams: {foo: '8', bar: '10', baz: '11' }}), "A new query param was added");
+  ok(!router.isActive('index', { queryParams: {foo: '8', bar: '11', }}), "A query param changed");
+});
+


### PR DESCRIPTION
Giving isActive support a whirl.
