### PR TITLE
willLeave and willChangeContext events

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -5,6 +5,7 @@ import TransitionState from './transition-state';
 import { logAbort, Transition, TransitionAborted } from './transition';
 import NamedTransitionIntent from './transition-intent/named-transition-intent';
 import URLTransitionIntent from './transition-intent/url-transition-intent';
+import { ResolvedHandlerInfo } from './handler-info';
 
 var pop = Array.prototype.pop;
 
@@ -126,7 +127,7 @@ Router.prototype = {
       }, null, promiseLabel("Settle transition promise when transition is finalized"));
 
       if (!wasTransitioning) {
-        trigger(this, this.state.handlerInfos, true, ['willTransition', newTransition]);
+        notifyExistingHandlers(this, newState, newTransition);
       }
 
       return newTransition;
@@ -725,6 +726,46 @@ function finalizeQueryParamChange(router, resolvedHandlers, newQueryParams, tran
     }
   }
   return finalQueryParams;
+}
+
+function notifyExistingHandlers(router, newState, newTransition) {
+  var oldHandlers = router.state.handlerInfos,
+      changing = [],
+      leavingIndex = null,
+      leaving, leavingChecker, i, oldHandler, newHandler;
+
+  for (i = 0; i < oldHandlers.length; i++) {
+    oldHandler = oldHandlers[i];
+    newHandler = newState.handlerInfos[i];
+
+    if (!newHandler || oldHandler.name !== newHandler.name) {
+      leavingIndex = i;
+      break;
+    }
+
+    if (!(newHandler instanceof ResolvedHandlerInfo)) {
+      changing.push(oldHandler);
+    }
+  }
+
+  if (leavingIndex !== null) {
+    leaving = oldHandlers.slice(leavingIndex, oldHandlers.length);
+    leavingChecker = function(name) {
+      for (var h = 0; h < leaving.length; h++) {
+        if (leaving[h].name === name) {
+          return true;
+        }
+      }
+      return false;
+    };
+    trigger(router, leaving, true, ['willLeave', newTransition, leavingChecker]);
+  }
+
+  if (changing.length > 0) {
+    trigger(router, changing, true, ['willChangeContext', newTransition]);
+  }
+
+  trigger(router, oldHandlers, true, ['willTransition', newTransition]);
 }
 
 export default Router;

--- a/test/tests/router_test.js
+++ b/test/tests/router_test.js
@@ -3045,3 +3045,147 @@ test("intermediateTransitionTo() forces an immediate intermediate transition tha
   counterAt(7, "original transition promise resolves");
 });
 
+module("willLeave and willChangeContext events", {
+  setup: function() {
+    handlers = {};
+
+    map(function(match) {
+      match("/people").to("people", function (match) {
+	match("/").to("peopleIndex");
+	match("/:id").to("person", function (match) {
+	  match("/").to("personIndex");
+	  match("/detail").to("personDetail");
+	});
+      });
+    });
+  }
+});
+
+asyncTest("trigger willLeave for routes that we're leaving", function() {
+  expect(1);
+
+  handlers = {
+    peopleIndex: {
+      events: {
+	willLeave: function(t){
+	  ok(true, 'peopleIndex willLeave');
+	},
+	willChangeContext: function(transition) {
+          ok(false, 'peopleIndex should not change context');
+        }
+      }
+    },
+    people: {
+      events: {
+        willLeave: function(transition) {
+          ok(false, 'people should not leave');
+        },
+	willChangeContext: function(transition) {
+          ok(false, 'people should not change context');
+        }
+      }
+    }
+  };
+
+  router.handleURL('/people').then(function() {
+    return router.handleURL('/people/1');
+  }).then(start, shouldNotHappen);
+  flushBackburner();
+});
+
+
+asyncTest("trigger willChangeContext for routes that are changing context", function() {
+  expect(1);
+
+  handlers = {
+    people: {
+      events: {
+        willLeave: function(transition) {
+          ok(false, 'people should not leave');
+        },
+	willChangeContext: function(transition) {
+          ok(false, 'people should not change context');
+        }
+      }
+    },
+    person: {
+      events: {
+        willLeave: function(transition) {
+          ok(false, 'person should not leave');
+        },
+	willChangeContext: function(transition) {
+          ok(true, 'person changes context');
+        }
+      }
+    }
+  };
+
+  router.handleURL('/people/1').then(function() {
+    return router.handleURL('/people/2');
+  }).then(start, shouldNotHappen);
+  flushBackburner();
+});
+
+asyncTest("doesn't trigger willChangeContext when only children change", function() {
+  expect(1);
+
+  handlers = {
+    people: {
+      events: {
+        willLeave: function(transition) {
+          ok(false, 'people should not leave');
+        },
+	willChangeContext: function(transition) {
+          ok(false, 'people should not change context');
+        }
+      }
+    },
+    person: {
+      events: {
+        willLeave: function(transition) {
+          ok(false, 'person should not leave');
+        },
+	willChangeContext: function(transition) {
+          ok(false, 'person should not change context');
+        }
+      }
+    },
+    personIndex: {
+      events: {
+        willLeave: function(transition) {
+          ok(true, 'personIndex should leave');
+        },
+	willChangeContext: function(transition) {
+          ok(false, 'personIndex should not change context');
+        }
+      }
+    }
+  };
+
+  router.handleURL('/people/1').then(function() {
+    return router.handleURL('/people/1/detail');
+  }).then(start, shouldNotHappen);
+  flushBackburner();
+});
+
+asyncTest("let handlers ask which other handlers are leaving", function() {
+  expect(2);
+
+  handlers = {
+    personIndex: {
+      events: {
+        willLeave: function(transition, alsoLeaving) {
+          ok(alsoLeaving("person"), "also leaving person");
+	  ok(!alsoLeaving("people"), "not also leaving people");
+        }
+      }
+    }
+  };
+
+  router.handleURL('/people/1').then(function() {
+    return router.handleURL('/people');
+  }).then(start, shouldNotHappen);
+  flushBackburner();
+});
+
+


### PR DESCRIPTION
This supercedes https://github.com/emberjs/ember.js/pull/4233

My intention is to expose a public API that's more fine-grained than `willTransition`. The problem with `willTransition` is that it fires on your route regardless of whether your route is actually going to be affected by the transition. The user is left crawling through private state on the transition object to figure out whether their route is really going away or changing context.

This change creates two new events: `willLeave` and `willChangeContext`. `willLeave` fires on routes that will no longer be active after the transition. `willChangeContext` fires on routes that will still be active but will re-resolve their models. Both of these hooks act like `willTransition` in the sense that they give you an opportunity to abort the transition before it happens. Common use cases include animating things away or prompting to user to deal with unsaved changes.

If this PR is merged, I'll make a (documentation-only) PR against ember itself. As far as I can tell, no code changes will be necessary there.

I left `willTransition` alone, so this should be backward compatible with stable Ember APIs.
