### PR TITLE
Transition.then accepts the label parameter

### DIFF
--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -113,9 +113,10 @@ Transition.prototype = {
 
     @param {Function} success
     @param {Function} failure
+    @param {String} label optional string for labeling the promise.
    */
-  then: function(success, failure) {
-    return this.promise.then(success, failure);
+  then: function(success, failure, label) {
+    return this.promise.then.apply(this.promise, arguments);
   },
 
   /**


### PR DESCRIPTION
Now, `then` accepts the same parameters than the `promise.then` implementation and passes all the arguments to the internal promise instance.
