### PR TITLE
'_id' variable name issue, increase MongoDB compatibility

### DIFF
--- a/dist/router.js
+++ b/dist/router.js
@@ -329,8 +329,8 @@ define("router/handler-info/unresolved-handler-info-by-object",
         if (names.length !== 1) { return; }
 
         var name = names[0];
-
-        if (/_id$/.test(name)) {
+        //object name shouldn't be empty. '_id' can be declared as variable name. 
+        if (/.+_id$/.test(name)) {
           object[name] = model.id;
         } else {
           object[name] = model;

--- a/lib/router/handler-info/unresolved-handler-info-by-object.js
+++ b/lib/router/handler-info/unresolved-handler-info-by-object.js
@@ -42,7 +42,7 @@ var UnresolvedHandlerInfoByObject = subclass(HandlerInfo, {
 
     var name = names[0];
 
-    if (/_id$/.test(name)) {
+    if (/.+_id$/.test(name)) {
       object[name] = model.id;
     } else {
       object[name] = model;

--- a/test/tests/router_test.js
+++ b/test/tests/router_test.js
@@ -18,6 +18,7 @@ module("The router", {
       });
       match("/posts", function(match) {
         match("/:id").to("showPost");
+        match("/id/:_id").to("showUnderscoredIdPost");
         match("/on/:date").to("showPostsForDate");
         match("/admin/:id").to("admin", function(match) {
           match("/posts").to("adminPosts");
@@ -80,6 +81,9 @@ function flush(expectedError) {
 test("Mapping adds named routes to the end", function() {
   url = router.recognizer.generate("showPost", { id: 1 });
   equal(url, "/posts/1");
+
+  url = router.recognizer.generate("showUnderscoredIdPost", { _id: 1 });
+  equal(url, "/posts/id/1");
 
   url = router.recognizer.generate("showAllPosts");
   equal(url, "/posts");


### PR DESCRIPTION
'_id' variable name which is used in model can be placed in the route path
increase MongoDB compatibility
'post_id' regEx should be ".+_id$" neither ".*_id$" nor "_id$"
