### PR TITLE
async hack, doesn't need to introduce a wasteful intermediate promise

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -348,9 +348,7 @@ Router.prototype = {
                       value returned from the callback
    */
   async: function(callback, label) {
-    return new Promise(function(resolve) {
-      resolve(callback());
-    }, label);
+    return callback();
   },
 
   /**


### PR DESCRIPTION
`async:` hack is silly, but lets at least make it not as wasteful
