### PR TITLE
Use current transition state as promise labels in resolve()

### DIFF
--- a/lib/router/transition-state.js
+++ b/lib/router/transition-state.js
@@ -44,13 +44,13 @@ TransitionState.prototype = {
     .then(resolveOneHandlerInfo, null, this.promiseLabel('Resolve handler'))['catch'](handleError, this.promiseLabel('Handle error'));
 
     function innerShouldContinue() {
-      return Promise.resolve(shouldContinue(), promiseLabel("Check if should continue"))['catch'](function(reason) {
+      return Promise.resolve(shouldContinue(), currentState.promiseLabel("Check if should continue"))['catch'](function(reason) {
         // We distinguish between errors that occurred
         // during resolution (e.g. beforeModel/model/afterModel),
         // and aborts due to a rejecting promise from shouldContinue().
         wasAborted = true;
         return Promise.reject(reason);
-      }, promiseLabel("Handle abort"));
+      }, currentState.promiseLabel("Handle abort"));
     }
 
     function handleError(error) {
@@ -87,7 +87,7 @@ TransitionState.prototype = {
 
       // Proceed after ensuring that the redirect hook
       // didn't abort this transition by transitioning elsewhere.
-      return innerShouldContinue().then(resolveOneHandlerInfo, null, promiseLabel('Resolve handler'));
+      return innerShouldContinue().then(resolveOneHandlerInfo, null, currentState.promiseLabel('Resolve handler'));
     }
 
     function resolveOneHandlerInfo() {
@@ -103,7 +103,7 @@ TransitionState.prototype = {
       var handlerInfo = currentState.handlerInfos[payload.resolveIndex];
 
       return handlerInfo.resolve(innerShouldContinue, payload)
-                        .then(proceed, null, promiseLabel('Proceed'));
+                        .then(proceed, null, currentState.promiseLabel('Proceed'));
     }
   }
 };


### PR DESCRIPTION
I believe this should use currentState.promiseLabel() instead of promiseLabel() from utils.
