### PR TITLE
reset() should trigger exit from leaf up

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -142,7 +142,7 @@ Router.prototype = {
   */
   reset: function() {
     if (this.state) {
-      forEach(this.state.handlerInfos, function(handlerInfo) {
+      forEach(this.state.handlerInfos.slice().reverse(), function(handlerInfo) {
         var handler = handlerInfo.handler;
         if (handler.exit) {
           handler.exit();

--- a/test/tests/router_test.js
+++ b/test/tests/router_test.js
@@ -1341,15 +1341,19 @@ test("calling transitionTo on a dynamic parent route causes non-dynamic child co
 test("reset exits and clears the current and target route handlers", function() {
   var postIndexExited = false;
   var showAllPostsExited = false;
+  var steps = 0;
 
+  equal(++steps, 1);
   var postIndexHandler = {
     exit: function() {
       postIndexExited = true;
+      equal(++steps, 4);
     }
   };
   var showAllPostsHandler = {
     exit: function() {
       showAllPostsExited = true;
+      equal(++steps, 3);
     }
   };
   handlers = {
@@ -1359,8 +1363,8 @@ test("reset exits and clears the current and target route handlers", function() 
 
   transitionTo(router, "/posts/all");
 
+  equal(++steps, 2);
   router.reset();
-  router.reset(); // two resets back to back should work
 
   ok(postIndexExited, "Post index handler did not exit");
   ok(showAllPostsExited, "Show all posts handler did not exit");


### PR DESCRIPTION
The reset() function documentation describes that it should trigger the exit from leaf up the ancestor chain. However, it was doing the reverse. I added some assertions to the reset-test to make sure that this works as described.
Additionally, I removed the second call for reset() since the tests seem to work without calling it twice. Possibly a previous bug?!
