### PR TITLE
Replace grunt-s3 with grunt-aws so builds are pushed to s3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "connect-redirection": "0.0.1",
     "ember-cli": "0.0.41",
     "grunt": "~0.4.2",
+    "grunt-aws": "^0.5.3",
     "grunt-broccoli": "^0.2.0",
     "grunt-cli": "~0.1.11",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-contrib-qunit": "~0.3.0",
-    "grunt-s3": "~0.2.0-alpha.2",
     "jshint": "~0.9",
     "load-grunt-config": "~0.5.0",
     "load-grunt-tasks": "~0.2.0"

--- a/tasks/options/s3.js
+++ b/tasks/options/s3.js
@@ -15,11 +15,10 @@ module.exports = {
   options: {
     bucket: 'routerjs.builds.emberjs.com',
     access: 'public-read',
-    key: '<%= env.S3_ACCESS_KEY_ID %>',
-    secret: '<%= env.S3_SECRET_ACCESS_KEY %>',
+    accessKeyId: '<%= env.S3_ACCESS_KEY_ID %>',
+    secretAccessKey: '<%= env.S3_SECRET_ACCESS_KEY %>',
   },
   dev: {
-    upload: s3Uploads
+    files: s3Uploads
   }
 };
-


### PR DESCRIPTION
The README indicates builds are pushed to s3. Looks like this stopped working over a year ago. Hoping this re-enables them.