### PR TITLE
handler-info: paramsMatch compares number of properties

### DIFF
--- a/lib/router/handler-info.js
+++ b/lib/router/handler-info.js
@@ -154,9 +154,10 @@ function paramsMatch(a, b) {
     return true;
   }
 
-  // Note: this assumes that both params have the same
-  // number of keys, but since we're comparing the
-  // same handlers, they should.
+  if (Object.keys(a).length !== Object.keys(b).length) {
+    return false;
+  }
+
   for (var k in a) {
     if (a.hasOwnProperty(k) && a[k] !== b[k]) {
       return false;


### PR DESCRIPTION
paramsMatch had a note that explained the assumption that incoming
params would have same number of keys. Rather than assume that, test
that they actually have the same number of keys.
