### PR TITLE
Correcting example function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ myHandlers.showPost = {
 
   // when coming in from `transitionTo`, convert an
   // object into parameters
-  serialize: function(object) {
+  serialize: function(post) {
     return { id: post.id };
   },
 


### PR DESCRIPTION
The code used to reference an undefined `posts` variable and did not use the passed parameter `object`. Later on down serialize is used again but does use its passed parameter, indicating that this one may be wrong.