### PR TITLE
Remove duplicate decode function

### DIFF
--- a/vendor/deps/route-recognizer.js
+++ b/vendor/deps/route-recognizer.js
@@ -448,7 +448,7 @@ define("route-recognizer",
         var pairs = queryString.split("&"), queryParams = {};
         for(var i=0; i < pairs.length; i++) {
           var pair      = pairs[i].split('='),
-              key       = decodeURIComponent(pair[0]),
+              key       = pair[0],
               keyLength = key.length,
               isArray = false,
               value;
@@ -463,12 +463,12 @@ define("route-recognizer",
                 queryParams[key] = [];
               }
             }
-            value = pair[1] ? decodeURIComponent(pair[1]) : '';
+            value = pair[1] ? pair[1] : '';
           }
           if (isArray) {
             queryParams[key].push(value);
           } else {
-            queryParams[key] = decodeURIComponent(value);
+            queryParams[key] = value;
           }
         }
         return queryParams;


### PR DESCRIPTION
I've found the issue when parameter value is '%' so my URL will be ...?parameterName=%25

At the first time at route-recognizer.js:482 
        path = decodeURI(path);
will decode the path to ...?parameterName=%
At the second attempt to decode by decodeURIComponent for each parameter pair, an exception will be thrown.

Uncaught URIError: URI malformed
    at decodeURIComponent (native)
    at Object.eval (eval at evaluate (unknown source), <anonymous>:1:1)
    at Object.InjectedScript._evaluateOn (<anonymous>:905:55)
    at Object.InjectedScript._evaluateAndWrap (<anonymous>:838:34)
    at Object.InjectedScript.evaluateOnCallFrame (<anonymous>:964:21)

Because it tries to decodeURIComponent('%')