### PR TITLE
Include package dependencies; bower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle
 /tmp
 /node_modules
+/bower_components
 
 dist/tests

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "router.js",
+  "description": "A lightweight JavaScript library is built on top of route-recognizer and rsvp.js to provide an API for handling routes",
+  "main": "router.js",
+  "authors": [
+    "Tilde",
+    "Inc."
+  ],
+  "license": "MIT",
+  "keywords": [
+    "router",
+    "route-recognizer",
+    "rsvp"
+  ],
+  "homepage": "https://github.com/tildeio/router.js",
+  "moduleType": [],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "route-recognizer": "~0.1.9"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "https://github.com/tildeio/router.js.git"
   },
+  "dependencies": {
+    "route-recognizer": "^0.1.9",
+    "rsvp": "^3.1.0"
+  },
   "devDependencies": {
     "broccoli": "^0.9.0",
     "broccoli-concat": "0.0.6",


### PR DESCRIPTION
Adds RSVP, route-recognizer to package.json.
Creates a simple bower.json that can be used
for registration and installation, but does not
include devDependencies, as Broccoli is not on
Bower.
