### PR TITLE
Make Transition#urlMethod public

### DIFF
--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -76,7 +76,6 @@ Transition.currentSequence = 0;
 
 Transition.prototype = {
   targetName: null,
-  urlMethod: 'update',
   intent: null,
   params: null,
   pivotHandler: null,
@@ -126,6 +125,22 @@ Transition.prototype = {
     @public
    */
   data: null,
+
+  /**
+    Indicates the URL-changing method to be employed at the end of a
+    successful transition. It can be anything falsy (indicating that
+    the URL will not be updated, e.g. because the URL was updated
+    before the transition began, such as the initial transition when
+    the application is booted), to `replace` (indicating that the URL
+    will be updated via `replaceWith`), or to any other truthy value
+    (indicating that the URL will be updated via `updateURL`). This
+    should be changed via the `method` method.
+
+    @property urlMethod
+    @type {String}
+    @public
+   */
+  urlMethod: 'update',
 
   /**
     A standard promise hook that resolves if the transition


### PR DESCRIPTION
Document this property and make it public so route hooks can detect the type (URL method) of transition that is occurring.

#169 documented the Transition class and specified several methods and properties as public or private. This is a follow-up in which I am proposing that we document the ```Transition#urlMethod``` property and make it public. The [Transition#method](https://github.com/tildeio/router.js/blob/master/lib/router/transition.js#L238) method that updates it is already public, so it seems to make sense to make it public as well, so there is a public way of reading it as well as writing it.

## Background

[This](https://github.com/emberjs/ember.js/issues/12824) issue describes a problem where a route that performs a redirect needs to know whether the transition's target URL is already in the history or not so it knows whether to call ```replaceWith()``` or ```transitionTo()``` in order to keep the navigation history correct.

The [workaround](https://github.com/emberjs/ember.js/issues/12824#issuecomment-172147220) described in the comments involves using the ```Transition#sequence``` property, which is currently private, only used for logging, and set based on an incrementing static class property that is not reset when the app resets (e.g. in unit tests). In short, a hack.

Making ```Transition#urlMethod``` public would provide a much cleaner workaround for the bug. Even ignoring that issue, it seems plausible that certain routes might want to make different decisions based on whether the transition they are handling is doing a replace, update, or not modifying the history.