### PR TITLE
Introduce getSerializer option

### DIFF
--- a/lib/router/handler-info/unresolved-handler-info-by-object.js
+++ b/lib/router/handler-info/unresolved-handler-info-by-object.js
@@ -25,7 +25,8 @@ var UnresolvedHandlerInfoByObject = subclass(HandlerInfo, {
   serialize: function(_model) {
     var model = _model || this.context,
         names = this.names,
-        handler = this.handler;
+        handler = this.handler,
+        serializer = this.serializer || (handler && handler.serialize);
 
     var object = {};
     if (isParam(model)) {
@@ -34,8 +35,8 @@ var UnresolvedHandlerInfoByObject = subclass(HandlerInfo, {
     }
 
     // Use custom serialize if it exists.
-    if (handler.serialize) {
-      return handler.serialize(model, names);
+    if (serializer) {
+      return serializer(model, names);
     }
 
     if (names.length !== 1) { return; }

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -12,6 +12,7 @@ var pop = Array.prototype.pop;
 function Router(_options) {
   var options = _options || {};
   this.getHandler = options.getHandler || this.getHandler;
+  this.getSerializer = options.getSerializer || this.getSerializer;
   this.updateURL = options.updateURL || this.updateURL;
   this.replaceURL = options.replaceURL || this.replaceURL;
   this.didTransition = options.didTransition || this.didTransition;
@@ -29,7 +30,7 @@ function getTransitionByIntent(intent, isIntermediate) {
   var oldState = wasTransitioning ? this.activeTransition.state : this.state;
   var newTransition;
 
-  var newState = intent.applyToState(oldState, this.recognizer, this.getHandler, isIntermediate);
+  var newState = intent.applyToState(oldState, this.recognizer, this.getHandler, isIntermediate, this.getSerializer);
   var queryParamChangelist = getChangelist(oldState.queryParams, newState.queryParams);
 
   if (handlerInfosEqual(newState.handlerInfos, oldState.handlerInfos)) {
@@ -104,6 +105,8 @@ Router.prototype = {
   },
 
   getHandler: function() {},
+
+  getSerializer: function() {},
 
   queryParamsTransition: function(changelist, wasTransitioning, oldState, newState) {
     var router = this;
@@ -277,7 +280,7 @@ Router.prototype = {
     // Construct a TransitionIntent with the provided params
     // and apply it to the present state of the router.
     var intent = new NamedTransitionIntent({ name: handlerName, contexts: suppliedParams });
-    var state = intent.applyToState(this.state, this.recognizer, this.getHandler);
+    var state = intent.applyToState(this.state, this.recognizer, this.getHandler, null, this.getSerializer);
     var params = {};
 
     for (var i = 0, len = state.handlerInfos.length; i < len; ++i) {
@@ -297,7 +300,7 @@ Router.prototype = {
     });
 
     var state = this.activeTransition && this.activeTransition.state || this.state;
-    return intent.applyToState(state, this.recognizer, this.getHandler);
+    return intent.applyToState(state, this.recognizer, this.getHandler, null, this.getSerializer);
   },
 
   isActiveIntent: function(handlerName, contexts, queryParams, _state) {
@@ -330,7 +333,7 @@ Router.prototype = {
       contexts: contexts
     });
 
-    var newState = intent.applyToHandlers(testState, recogHandlers, this.getHandler, targetHandler, true, true);
+    var newState = intent.applyToHandlers(testState, recogHandlers, this.getHandler, targetHandler, true, true, this.getSerializer);
 
     var handlersEqual = handlerInfosEqual(newState.handlerInfos, testState.handlerInfos);
     if (!queryParams || !handlersEqual) {

--- a/lib/router/transition-intent/named-transition-intent.js
+++ b/lib/router/transition-intent/named-transition-intent.js
@@ -16,7 +16,7 @@ export default subclass(TransitionIntent, {
     this.queryParams = props.queryParams;
   },
 
-  applyToState: function(oldState, recognizer, getHandler, isIntermediate) {
+  applyToState: function(oldState, recognizer, getHandler, isIntermediate, getSerializer) {
 
     var partitionedArgs     = extractQueryParams([this.name].concat(this.contexts)),
       pureArgs              = partitionedArgs[0],
@@ -25,10 +25,10 @@ export default subclass(TransitionIntent, {
 
     var targetRouteName = handlers[handlers.length-1].handler;
 
-    return this.applyToHandlers(oldState, handlers, getHandler, targetRouteName, isIntermediate);
+    return this.applyToHandlers(oldState, handlers, getHandler, targetRouteName, isIntermediate, null, getSerializer);
   },
 
-  applyToHandlers: function(oldState, handlers, getHandler, targetRouteName, isIntermediate, checkingIfActive) {
+  applyToHandlers: function(oldState, handlers, getHandler, targetRouteName, isIntermediate, checkingIfActive, getSerializer) {
 
     var i, len;
     var newState = new TransitionState();
@@ -60,7 +60,8 @@ export default subclass(TransitionIntent, {
         if (i >= invalidateIndex) {
           newHandlerInfo = this.createParamHandlerInfo(name, handler, result.names, objects, oldHandlerInfo);
         } else {
-          newHandlerInfo = this.getHandlerInfoForDynamicSegment(name, handler, result.names, objects, oldHandlerInfo, targetRouteName, i);
+          var serializer = getSerializer(name);
+          newHandlerInfo = this.getHandlerInfoForDynamicSegment(name, handler, result.names, objects, oldHandlerInfo, targetRouteName, i, serializer);
         }
       } else {
         // This route has no dynamic segment.
@@ -118,7 +119,7 @@ export default subclass(TransitionIntent, {
     }
   },
 
-  getHandlerInfoForDynamicSegment: function(name, handler, names, objects, oldHandlerInfo, targetRouteName, i) {
+  getHandlerInfoForDynamicSegment: function(name, handler, names, objects, oldHandlerInfo, targetRouteName, i, serializer) {
 
     var numNames = names.length;
     var objectToUse;
@@ -153,6 +154,7 @@ export default subclass(TransitionIntent, {
     return handlerInfoFactory('object', {
       name: name,
       handler: handler,
+      serializer: serializer,
       context: objectToUse,
       names: names
     });

--- a/test/tests/router_test.js
+++ b/test/tests/router_test.js
@@ -1158,6 +1158,32 @@ test("Date params aren't treated as string/number params", function() {
   equal(router.generate('showPostsForDate', new Date(1815, 5, 18)), "/posts/on/1815-5-18");
 });
 
+test("getSerializer takes precedence over handler.serialize", function() {
+  expect(2);
+
+  router.getSerializer = function() {
+    return function(date) {
+      ok(true, "getSerializer called");
+      return { date: date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate() };
+    };
+  };
+
+  handlers = {
+    showPostsForDate: {
+      serialize: function(date) {
+        ok(false, "serialize method shouldn't be called");
+        return {};
+      },
+
+      model: function(params) {
+        ok(false, "model shouldn't be called; the date is the provided model");
+      }
+    }
+  };
+
+  equal(router.generate('showPostsForDate', new Date(1815, 5, 18)), "/posts/on/1815-5-18");
+});
+
 test("params are known by a transition up front", function() {
   expect(2);
 

--- a/test/tests/transition_intent_test.js
+++ b/test/tests/transition_intent_test.js
@@ -68,6 +68,8 @@ module("TransitionIntent", {
   }
 });
 
+function getSerializer() {}
+
 function getHandler(name) {
   if (handlers[name]) {
     return handlers[name];
@@ -208,7 +210,7 @@ test("NamedTransitionIntent applied to an already-resolved handlerInfo (non-empt
     contexts: [ article, comment ]
   });
 
-  var newState = intent.applyToState(state, recognizer, getHandler);
+  var newState = intent.applyToState(state, recognizer, getHandler, null, getSerializer);
   var handlerInfos = newState.handlerInfos;
 
   equal(handlerInfos.length, 2);


### PR DESCRIPTION
Allows the logic for linking to a route (e.g., constructing urls) to be separated from the logic needed to enter a route.

This is a corollary to the [Route Serializers RFC from Ember.js](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md). The main goal here is to enable URLs/links for a route to be constructed _before_ a route's handler has been loaded. This will help enable the ability to lazy-load routes. The next step will be to allow `getHandler` to return a Promise value for a handler.

cc @dgeb @rwjblue 