### PR TITLE
Restrict globals usage and remove QUnit globals usage

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,24 +1,9 @@
 {
     "predef": [
-        "console",
-        "define",
-        "require",
-        "requireModule",
-        "equal",
-        "test",
-        "asyncTest",
-        "throws",
-        "deepEqual",
-        "start",
-        "stop",
-        "ok",
-        "strictEqual",
-        "module",
-        "QUnit",
-        "expect"
+        "QUnit"
     ],
 
-    "node" : true,
+    "node" : false,
     "browser" : true,
 
     "boss" : true,

--- a/test/tests/handler_info_test.js
+++ b/test/tests/handler_info_test.js
@@ -1,4 +1,4 @@
-import { module, stubbedHandlerInfoFactory } from "tests/test_helpers";
+import { module, test, stubbedHandlerInfoFactory } from "tests/test_helpers";
 
 import HandlerInfo from 'router/handler-info';
 
@@ -32,57 +32,57 @@ function create(Klass, _props) {
 
 module("HandlerInfo");
 
-test("ResolvedHandlerInfos resolve to themselves", function() {
+test("ResolvedHandlerInfos resolve to themselves", function(assert) {
   var handlerInfo = new ResolvedHandlerInfo();
   handlerInfo.resolve().then(function(resolvedHandlerInfo) {
-    equal(handlerInfo, resolvedHandlerInfo);
+    assert.equal(handlerInfo, resolvedHandlerInfo);
   });
 });
 
-test("UnresolvedHandlerInfoByParam defaults params to {}", function() {
+test("UnresolvedHandlerInfoByParam defaults params to {}", function(assert) {
   var handlerInfo = new UnresolvedHandlerInfoByParam();
-  deepEqual(handlerInfo.params, {});
+  assert.deepEqual(handlerInfo.params, {});
 
   var handlerInfo2 = new UnresolvedHandlerInfoByParam({ params: { foo: 5 } });
-  deepEqual(handlerInfo2.params, { foo: 5 });
+  assert.deepEqual(handlerInfo2.params, { foo: 5 });
 });
 
-test("HandlerInfo can be aborted mid-resolve", function() {
+test("HandlerInfo can be aborted mid-resolve", function(assert) {
 
-  expect(2);
+  assert.expect(2);
 
   var handlerInfo = create(StubHandlerInfo);
 
   function abortResolve() {
-    ok(true, "abort was called");
+    assert.ok(true, "abort was called");
     return reject("LOL");
   }
 
   handlerInfo.resolve(abortResolve, {}).catch(function(error) {
-    equal(error, "LOL");
+    assert.equal(error, "LOL");
   });
 });
 
-test("HandlerInfo#resolve resolves with a ResolvedHandlerInfo", function() {
-  expect(1);
+test("HandlerInfo#resolve resolves with a ResolvedHandlerInfo", function(assert) {
+  assert.expect(1);
 
   var handlerInfo = create(StubHandlerInfo);
 
   handlerInfo.resolve(noop, {}).then(function(resolvedHandlerInfo) {
-    equal(resolvedHandlerInfo._handlerInfoType, 'resolved');
+    assert.equal(resolvedHandlerInfo._handlerInfoType, 'resolved');
   });
 });
 
-test("HandlerInfo#resolve runs beforeModel hook on handler", function() {
+test("HandlerInfo#resolve runs beforeModel hook on handler", function(assert) {
 
-  expect(1);
+  assert.expect(1);
 
   var transition = {};
 
   var handlerInfo = create(StubHandlerInfo, {
     handler: {
       beforeModel: function(payload) {
-        equal(transition, payload, "beforeModel was called with the payload we passed to resolve()");
+        assert.equal(transition, payload, "beforeModel was called with the payload we passed to resolve()");
       }
     }
   });
@@ -90,15 +90,15 @@ test("HandlerInfo#resolve runs beforeModel hook on handler", function() {
   handlerInfo.resolve(noop, transition);
 });
 
-test("HandlerInfo#resolve runs getModel hook", function() {
+test("HandlerInfo#resolve runs getModel hook", function(assert) {
 
-  expect(1);
+  assert.expect(1);
 
   var transition = {};
 
   var handlerInfo = create(StubHandlerInfo, {
     getModel: function(payload) {
-      equal(payload, transition);
+      assert.equal(payload, transition);
     }
   });
   handlerInfo.factory = stubbedHandlerInfoFactory;
@@ -106,9 +106,9 @@ test("HandlerInfo#resolve runs getModel hook", function() {
   handlerInfo.resolve(noop, transition);
 });
 
-test("HandlerInfo#resolve runs afterModel hook on handler", function() {
+test("HandlerInfo#resolve runs afterModel hook on handler", function(assert) {
 
-  expect(3);
+  assert.expect(3);
 
   var transition = {};
   var model = {};
@@ -116,8 +116,8 @@ test("HandlerInfo#resolve runs afterModel hook on handler", function() {
   var handlerInfo = new HandlerInfo({
     handler: {
       afterModel: function(resolvedModel, payload) {
-        equal(resolvedModel, model, "afterModel receives the value resolved by model");
-        equal(payload, transition);
+        assert.equal(resolvedModel, model, "afterModel receives the value resolved by model");
+        assert.equal(payload, transition);
         return resolve(123); // 123 should get ignored
       }
     },
@@ -129,20 +129,20 @@ test("HandlerInfo#resolve runs afterModel hook on handler", function() {
   });
 
   handlerInfo.resolve(noop, transition).then(function(resolvedHandlerInfo) {
-    equal(resolvedHandlerInfo.context, model, "HandlerInfo resolved with correct model");
+    assert.equal(resolvedHandlerInfo.context, model, "HandlerInfo resolved with correct model");
   });
 });
 
-test("UnresolvedHandlerInfoByParam gets its model hook called", function() {
-  expect(2);
+test("UnresolvedHandlerInfoByParam gets its model hook called", function(assert) {
+  assert.expect(2);
 
   var transition = {};
 
   var handlerInfo = new UnresolvedHandlerInfoByParam({
     handler: {
       model: function(params, payload) {
-        equal(payload, transition);
-        deepEqual(params, { first_name: 'Alex', last_name: 'Matchnerd' });
+        assert.equal(payload, transition);
+        assert.deepEqual(params, { first_name: 'Alex', last_name: 'Matchnerd' });
       }
     },
 
@@ -152,14 +152,14 @@ test("UnresolvedHandlerInfoByParam gets its model hook called", function() {
   handlerInfo.resolve(noop, transition);
 });
 
-test("UnresolvedHandlerInfoByObject does NOT get its model hook called", function() {
-  expect(1);
+test("UnresolvedHandlerInfoByObject does NOT get its model hook called", function(assert) {
+  assert.expect(1);
 
 
   var handlerInfo = create(UnresolvedHandlerInfoByObject, {
     handler: {
       model: function() {
-        ok(false, "I shouldn't be called because I already have a context/model");
+        assert.ok(false, "I shouldn't be called because I already have a context/model");
       }
     },
     names: ['wat'],
@@ -167,7 +167,7 @@ test("UnresolvedHandlerInfoByObject does NOT get its model hook called", functio
   });
 
   handlerInfo.resolve(noop, {}).then(function(resolvedHandlerInfo) {
-    equal(resolvedHandlerInfo.context.name, 'dorkletons');
+    assert.equal(resolvedHandlerInfo.context.name, 'dorkletons');
   });
 });
 

--- a/test/tests/query_params_test.js
+++ b/test/tests/query_params_test.js
@@ -1,4 +1,4 @@
-import { module, flushBackburner, transitionTo } from "tests/test_helpers";
+import { module, test, flushBackburner, transitionTo } from "tests/test_helpers";
 import Router from "router";
 import { Promise } from "rsvp";
 
@@ -21,11 +21,11 @@ var scenarios = [
 scenarios.forEach(function(scenario) {
 
 module("Query Params (" + scenario.name + ")", {
-  setup: function() {
+  setup: function(assert) {
     handlers = {};
     expectedUrl = null;
 
-    map(function(match) {
+    map(assert, function(match) {
       match("/index").to("index");
       match("/parent").to("parent", function(match) {
         match("/").to("parentIndex");
@@ -35,7 +35,7 @@ module("Query Params (" + scenario.name + ")", {
   }
 });
 
-function map(fn) {
+function map(assert, fn) {
   router = new Router();
   router.map(fn);
 
@@ -44,7 +44,7 @@ function map(fn) {
   router.updateURL = function(newUrl) {
 
     if (expectedUrl) {
-      equal(newUrl, expectedUrl, "The url is " + newUrl+ " as expected");
+      assert.equal(newUrl, expectedUrl, "The url is " + newUrl+ " as expected");
     }
 
     url = newUrl;
@@ -60,13 +60,13 @@ function consumeAllFinalQueryParams(params, finalParams) {
   return true;
 }
 
-test("a change in query params fires a queryParamsDidChange event", function() {
-  expect(7);
+test("a change in query params fires a queryParamsDidChange event", function(assert) {
+  assert.expect(7);
 
   var count = 0;
   handlers.index = {
     setup: function() {
-      equal(count, 0, "setup should be called exactly once since we're only changing query params after the first transition");
+      assert.equal(count, 0, "setup should be called exactly once since we're only changing query params after the first transition");
     },
     events: {
       finalizeQueryParamChange: consumeAllFinalQueryParams,
@@ -74,19 +74,19 @@ test("a change in query params fires a queryParamsDidChange event", function() {
       queryParamsDidChange: function(changed, all) {
         switch (count) {
           case 0:
-            ok(false, "shouldn't fire on first trans");
+            assert.ok(false, "shouldn't fire on first trans");
             break;
           case 1:
-            deepEqual(changed, { foo: '5' });
-            deepEqual(all,     { foo: '5' });
+            assert.deepEqual(changed, { foo: '5' });
+            assert.deepEqual(all,     { foo: '5' });
             break;
           case 2:
-            deepEqual(changed, { bar: '6' });
-            deepEqual(all,     { foo: '5', bar: '6' });
+            assert.deepEqual(changed, { bar: '6' });
+            assert.deepEqual(all,     { foo: '5', bar: '6' });
             break;
           case 3:
-            deepEqual(changed, { foo: '8', bar: '9' });
-            deepEqual(all,     { foo: '8', bar: '9' });
+            assert.deepEqual(changed, { foo: '8', bar: '9' });
+            assert.deepEqual(all,     { foo: '8', bar: '9' });
             break;
         }
       }
@@ -102,8 +102,8 @@ test("a change in query params fires a queryParamsDidChange event", function() {
   transitionTo(router, '/index?foo=8&bar=9');
 });
 
-test("transitioning between routes fires a queryParamsDidChange event", function() {
-  expect(8);
+test("transitioning between routes fires a queryParamsDidChange event", function(assert) {
+  assert.expect(8);
   var count = 0;
   handlers.parent = {
     events: {
@@ -111,23 +111,23 @@ test("transitioning between routes fires a queryParamsDidChange event", function
       queryParamsDidChange: function(changed, all) {
         switch (count) {
           case 0:
-            ok(false, "shouldn't fire on first trans");
+            assert.ok(false, "shouldn't fire on first trans");
             break;
           case 1:
-            deepEqual(changed, { foo: '5' });
-            deepEqual(all,     { foo: '5' });
+            assert.deepEqual(changed, { foo: '5' });
+            assert.deepEqual(all,     { foo: '5' });
             break;
           case 2:
-            deepEqual(changed, { bar: '6' });
-            deepEqual(all,     { foo: '5', bar: '6' });
+            assert.deepEqual(changed, { bar: '6' });
+            assert.deepEqual(all,     { foo: '5', bar: '6' });
             break;
           case 3:
-            deepEqual(changed, { foo: '8', bar: '9' });
-            deepEqual(all,     { foo: '8', bar: '9' });
+            assert.deepEqual(changed, { foo: '8', bar: '9' });
+            assert.deepEqual(all,     { foo: '8', bar: '9' });
             break;
           case 4:
-            deepEqual(changed, { foo: '10', bar: '11'});
-            deepEqual(all,     { foo: '10', bar: '11'});
+            assert.deepEqual(changed, { foo: '10', bar: '11'});
+            assert.deepEqual(all,     { foo: '10', bar: '11'});
         }
       }
     }
@@ -157,30 +157,30 @@ test("transitioning between routes fires a queryParamsDidChange event", function
 
 });
 
-test("a handler can opt into a full-on transition by calling refresh", function() {
-  expect(3);
+test("a handler can opt into a full-on transition by calling refresh", function(assert) {
+  assert.expect(3);
 
   var count = 0;
   handlers.index = {
     model: function() {
       switch (count) {
         case 0:
-          ok(true, "model called in initial transition");
+          assert.ok(true, "model called in initial transition");
           break;
         case 1:
-          ok(true, "model called during refresh");
+          assert.ok(true, "model called during refresh");
           break;
         case 2:
-          ok(true, "model called during refresh w 2 QPs");
+          assert.ok(true, "model called during refresh w 2 QPs");
           break;
         default:
-          ok(false, "shouldn't have been called for " + count);
+          assert.ok(false, "shouldn't have been called for " + count);
       }
     },
     events: {
       queryParamsDidChange: function() {
         if (count === 0) {
-          ok(false, "shouldn't fire on first trans");
+          assert.ok(false, "shouldn't fire on first trans");
         } else {
           router.refresh(this);
         }
@@ -197,30 +197,30 @@ test("a handler can opt into a full-on transition by calling refresh", function(
 });
 
 
-test("at the end of a query param change a finalizeQueryParamChange event is fired", function() {
-  expect(5);
+test("at the end of a query param change a finalizeQueryParamChange event is fired", function(assert) {
+  assert.expect(5);
 
   var eventHandled = false;
   var count = 0;
   handlers.index = {
     setup: function() {
-      ok(!eventHandled, "setup should happen before eventHandled");
+      assert.notOk(eventHandled, "setup should happen before eventHandled");
     },
     events: {
       finalizeQueryParamChange: function(all) {
         eventHandled = true;
         switch (count) {
           case 0:
-            deepEqual(all, {});
+            assert.deepEqual(all, {});
             break;
           case 1:
-            deepEqual(all, { foo: '5' });
+            assert.deepEqual(all, { foo: '5' });
             break;
           case 2:
-            deepEqual(all, { foo: '5', bar: '6' });
+            assert.deepEqual(all, { foo: '5', bar: '6' });
             break;
           case 3:
-            deepEqual(all, { foo: '8', bar: '9' });
+            assert.deepEqual(all, { foo: '8', bar: '9' });
             break;
         }
       }
@@ -236,22 +236,22 @@ test("at the end of a query param change a finalizeQueryParamChange event is fir
   transitionTo(router, '/index?foo=8&bar=9');
 });
 
-test("failing to consume QPs in finalize event tells the router it no longer has those params", function() {
-  expect(2);
+test("failing to consume QPs in finalize event tells the router it no longer has those params", function(assert) {
+  assert.expect(2);
 
   handlers.index = {
     setup: function() {
-      ok(true, "setup was entered");
+      assert.ok(true, "setup was entered");
     }
   };
 
   transitionTo(router, '/index?foo=8&bar=9');
 
-  deepEqual(router.state.queryParams, {});
+  assert.deepEqual(router.state.queryParams, {});
 });
 
-test("consuming QPs in finalize event tells the router those params are active", function() {
-  expect(1);
+test("consuming QPs in finalize event tells the router those params are active", function(assert) {
+  assert.expect(1);
 
   handlers.index = {
     events: {
@@ -262,11 +262,11 @@ test("consuming QPs in finalize event tells the router those params are active",
   };
 
   transitionTo(router, '/index?foo=8&bar=9');
-  deepEqual(router.state.queryParams, { foo: '8' });
+  assert.deepEqual(router.state.queryParams, { foo: '8' });
 });
 
-test("can hide query params from URL if they're marked as visible=false in finalizeQueryParamChange", function() {
-  expect(2);
+test("can hide query params from URL if they're marked as visible=false in finalizeQueryParamChange", function(assert) {
+  assert.expect(2);
 
   handlers.index = {
     events: {
@@ -279,11 +279,11 @@ test("can hide query params from URL if they're marked as visible=false in final
 
   expectedUrl = '/index?bar=9';
   transitionTo(router, '/index?foo=8&bar=9');
-  deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
+  assert.deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
 });
 
-test("transitionTo() works with single query param arg", function() {
-  expect(2);
+test("transitionTo() works with single query param arg", function(assert) {
+  assert.expect(2);
 
   handlers.index = {
     events: {
@@ -295,47 +295,47 @@ test("transitionTo() works with single query param arg", function() {
   };
 
   transitionTo(router, '/index?bar=9&foo=8');
-  deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
+  assert.deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
 
   expectedUrl = '/index?foo=123';
   transitionTo(router, { queryParams: { foo: '123' }});
 });
 
-test("handleURL will NOT follow up with a replace URL if query params are already in sync", function() {
-  expect(0);
+test("handleURL will NOT follow up with a replace URL if query params are already in sync", function(assert) {
+  assert.expect(0);
 
   router.replaceURL = function(url) {
-    ok(false, "query params are in sync, this replaceURL shouldn't happen: " + url);
+    assert.ok(false, "query params are in sync, this replaceURL shouldn't happen: " + url);
   };
 
   router.handleURL('/index');
 });
 
-test("model hook receives queryParams", function() {
+test("model hook receives queryParams", function(assert) {
 
-  expect(1);
+  assert.expect(1);
 
   handlers.index = {
     model: function(params) {
-      deepEqual(params, { queryParams: { foo: '5' } });
+      assert.deepEqual(params, { queryParams: { foo: '5' } });
     }
   };
 
   transitionTo(router, '/index?foo=5');
 });
 
-test("can cause full transition by calling refresh within queryParamsDidChange", function() {
+test("can cause full transition by calling refresh within queryParamsDidChange", function(assert) {
 
-  expect(5);
+  assert.expect(5);
 
   var modelCount = 0;
   handlers.index = {
     model: function(params) {
       ++modelCount;
       if (modelCount === 1) {
-        deepEqual(params, { queryParams: { foo: '5' } });
+        assert.deepEqual(params, { queryParams: { foo: '5' } });
       } else if (modelCount === 2) {
-        deepEqual(params, { queryParams: { foo: '6' } });
+        assert.deepEqual(params, { queryParams: { foo: '6' } });
       }
     },
     events: {
@@ -345,22 +345,22 @@ test("can cause full transition by calling refresh within queryParamsDidChange",
     }
   };
 
-  equal(modelCount, 0);
+  assert.equal(modelCount, 0);
   transitionTo(router, '/index?foo=5');
-  equal(modelCount, 1);
+  assert.equal(modelCount, 1);
   transitionTo(router, '/index?foo=6');
-  equal(modelCount, 2);
+  assert.equal(modelCount, 2);
 });
 
-test("can retry a query-params refresh", function() {
+test("can retry a query-params refresh", function(assert) {
   var causeRedirect = false;
 
-  map(function(match) {
+  map(assert, function(match) {
     match("/index").to("index");
     match("/login").to("login");
   });
 
-  expect(11);
+  assert.expect(11);
 
   var redirect = false;
   var indexTransition;
@@ -372,11 +372,11 @@ test("can retry a query-params refresh", function() {
       }
     },
     setup: function() {
-      ok(true, "index#setup");
+      assert.ok(true, "index#setup");
     },
     events: {
       queryParamsDidChange: function() {
-        ok(true, "index#queryParamsDidChange");
+        assert.ok(true, "index#queryParamsDidChange");
         redirect = causeRedirect;
         router.refresh(this);
       },
@@ -389,7 +389,7 @@ test("can retry a query-params refresh", function() {
 
   handlers.login = {
     setup: function() {
-      ok(true, "login#setup");
+      assert.ok(true, "login#setup");
     }
   };
 
@@ -401,13 +401,13 @@ test("can retry a query-params refresh", function() {
   flushBackburner();
   causeRedirect = false;
   redirect = false;
-  ok(indexTransition, "index transition was saved");
+  assert.ok(indexTransition, "index transition was saved");
   indexTransition.retry();
   expectedUrl = '/index?foo=def';
 });
 
-test("tests whether query params to transitionTo are considered active", function() {
-  expect(6);
+test("tests whether query params to transitionTo are considered active", function(assert) {
+  assert.expect(6);
 
   handlers.index = {
     events: {
@@ -419,16 +419,16 @@ test("tests whether query params to transitionTo are considered active", functio
   };
 
   transitionTo(router, '/index?foo=8&bar=9');
-  deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
-  ok(router.isActive('index', { queryParams: {foo: '8', bar: '9' }}), "The index handler is active");
-  ok(router.isActive('index', { queryParams: {foo: 8, bar: 9 }}), "Works when property is number");
-  ok(!router.isActive('index', { queryParams: {foo: '9'}}), "Only supply one changed query param");
-  ok(!router.isActive('index', { queryParams: {foo: '8', bar: '10', baz: '11' }}), "A new query param was added");
-  ok(!router.isActive('index', { queryParams: {foo: '8', bar: '11', }}), "A query param changed");
+  assert.deepEqual(router.state.queryParams, { foo: '8', bar: '9' });
+  assert.ok(router.isActive('index', { queryParams: {foo: '8', bar: '9' }}), "The index handler is active");
+  assert.ok(router.isActive('index', { queryParams: {foo: 8, bar: 9 }}), "Works when property is number");
+  assert.notOk(router.isActive('index', { queryParams: {foo: '9'}}), "Only supply one changed query param");
+  assert.notOk(router.isActive('index', { queryParams: {foo: '8', bar: '10', baz: '11' }}), "A new query param was added");
+  assert.notOk(router.isActive('index', { queryParams: {foo: '8', bar: '11', }}), "A query param changed");
 });
 
-test("tests whether array query params to transitionTo are considered active", function() {
-  expect(7);
+test("tests whether array query params to transitionTo are considered active", function(assert) {
+  assert.expect(7);
 
   handlers.index = {
     events: {
@@ -439,13 +439,13 @@ test("tests whether array query params to transitionTo are considered active", f
   };
 
   transitionTo(router, '/index?foo[]=1&foo[]=2');
-  deepEqual(router.state.queryParams, { foo: ['1', '2']});
-  ok(router.isActive('index', { queryParams: {foo: ['1', '2'] }}), "The index handler is active");
-  ok(router.isActive('index', { queryParams: {foo: [1, 2] }}), "Works when array has numeric elements");
-  ok(!router.isActive('index', { queryParams: {foo: ['2', '1']}}), "Change order");
-  ok(!router.isActive('index', { queryParams: {foo: ['1', '2', '3']}}), "Change Length");
-  ok(!router.isActive('index', { queryParams: {foo: ['3', '4']}}), "Change Content");
-  ok(!router.isActive('index', { queryParams: {foo: []}}), "Empty Array");
+  assert.deepEqual(router.state.queryParams, { foo: ['1', '2']});
+  assert.ok(router.isActive('index', { queryParams: {foo: ['1', '2'] }}), "The index handler is active");
+  assert.ok(router.isActive('index', { queryParams: {foo: [1, 2] }}), "Works when array has numeric elements");
+  assert.notOk(router.isActive('index', { queryParams: {foo: ['2', '1']}}), "Change order");
+  assert.notOk(router.isActive('index', { queryParams: {foo: ['1', '2', '3']}}), "Change Length");
+  assert.notOk(router.isActive('index', { queryParams: {foo: ['3', '4']}}), "Change Content");
+  assert.notOk(router.isActive('index', { queryParams: {foo: []}}), "Empty Array");
 });
 
 });

--- a/test/tests/transition_intent_test.js
+++ b/test/tests/transition_intent_test.js
@@ -1,4 +1,4 @@
-import { module } from "tests/test_helpers";
+import { module, test } from "tests/test_helpers";
 import URLTransitionIntent from 'router/transition-intent/url-transition-intent';
 import NamedTransitionIntent from 'router/transition-intent/named-transition-intent';
 import TransitionState from 'router/transition-state';
@@ -33,13 +33,13 @@ scenarios.forEach(function(scenario) {
 
 // Asserts that a handler from a handlerInfo equals an expected valued.
 // Returns a promise during async scenarios to wait until the handler is ready.
-function assertHandlerEquals(handlerInfo, expected) {
+function assertHandlerEquals(assert, handlerInfo, expected) {
   if (!scenario.async) {
-    return equal(handlerInfo.handler, expected);
+    return assert.equal(handlerInfo.handler, expected);
   } else {
-    equal(handlerInfo.handler, undefined);
+    assert.equal(handlerInfo.handler, undefined);
     return handlerInfo.handlerPromise.then(function(handler) {
-      equal(handler, expected);
+      assert.equal(handler, expected);
     });
   }
 }
@@ -102,22 +102,22 @@ module("TransitionIntent (" + scenario.name + ")", {
   }
 });
 
-test("URLTransitionIntent can be applied to an empty state", function() {
+test("URLTransitionIntent can be applied to an empty state", function(assert) {
   var state = new TransitionState();
   var intent = new URLTransitionIntent({ url: '/foo/bar' });
   var newState = intent.applyToState(state, recognizer, scenario.getHandler);
   var handlerInfos = newState.handlerInfos;
 
-  equal(handlerInfos.length, 2);
-  ok(!handlerInfos[0].isResolved, "generated state consists of unresolved handler info, 1");
-  ok(!handlerInfos[1].isResolved, "generated state consists of unresolved handler info, 2");
+  assert.equal(handlerInfos.length, 2);
+  assert.notOk(handlerInfos[0].isResolved, "generated state consists of unresolved handler info, 1");
+  assert.notOk(handlerInfos[1].isResolved, "generated state consists of unresolved handler info, 2");
   Promise.all([
-    assertHandlerEquals(handlerInfos[0], handlers.foo),
-    assertHandlerEquals(handlerInfos[1], handlers.bar)
+    assertHandlerEquals(assert, handlerInfos[0], handlers.foo),
+    assertHandlerEquals(assert, handlerInfos[1], handlers.bar)
   ]);
 });
 
-test("URLTransitionIntent applied to single unresolved URL handlerInfo", function() {
+test("URLTransitionIntent applied to single unresolved URL handlerInfo", function(assert) {
   var state = new TransitionState();
 
   var startingHandlerInfo = new UnresolvedHandlerInfoByParam({
@@ -137,13 +137,13 @@ test("URLTransitionIntent applied to single unresolved URL handlerInfo", functio
   var newState = intent.applyToState(state, recognizer, scenario.getHandler);
   var handlerInfos = newState.handlerInfos;
 
-  equal(handlerInfos.length, 2);
-  equal(handlerInfos[0], startingHandlerInfo, "The starting foo handlerInfo wasn't overridden because the new one wasn't any different");
-  ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
-  assertHandlerEquals(handlerInfos[1], handlers.bar);
+  assert.equal(handlerInfos.length, 2);
+  assert.equal(handlerInfos[0], startingHandlerInfo, "The starting foo handlerInfo wasn't overridden because the new one wasn't any different");
+  assert.ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
+  assertHandlerEquals(assert, handlerInfos[1], handlers.bar);
 });
 
-test("URLTransitionIntent applied to an already-resolved handlerInfo", function() {
+test("URLTransitionIntent applied to an already-resolved handlerInfo", function(assert) {
   var state = new TransitionState();
 
   var startingHandlerInfo = new ResolvedHandlerInfo({
@@ -159,13 +159,13 @@ test("URLTransitionIntent applied to an already-resolved handlerInfo", function(
   var newState = intent.applyToState(state, recognizer, scenario.getHandler);
   var handlerInfos = newState.handlerInfos;
 
-  equal(handlerInfos.length, 2);
-  equal(handlerInfos[0], startingHandlerInfo, "The starting foo resolved handlerInfo wasn't overridden because the new one wasn't any different");
-  ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
-  assertHandlerEquals(handlerInfos[1], handlers.bar);
+  assert.equal(handlerInfos.length, 2);
+  assert.equal(handlerInfos[0], startingHandlerInfo, "The starting foo resolved handlerInfo wasn't overridden because the new one wasn't any different");
+  assert.ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
+  assertHandlerEquals(assert, handlerInfos[1], handlers.bar);
 });
 
-test("URLTransitionIntent applied to an already-resolved handlerInfo (non-empty params)", function() {
+test("URLTransitionIntent applied to an already-resolved handlerInfo (non-empty params)", function(assert) {
   var state = new TransitionState();
 
   var article = {};
@@ -183,13 +183,13 @@ test("URLTransitionIntent applied to an already-resolved handlerInfo (non-empty 
   var newState = intent.applyToState(state, recognizer, scenario.getHandler);
   var handlerInfos = newState.handlerInfos;
 
-  equal(handlerInfos.length, 2);
-  ok(handlerInfos[0] !== startingHandlerInfo, "The starting foo resolved handlerInfo was overridden because the new had different params");
-  ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
-  assertHandlerEquals(handlerInfos[1], handlers.comments);
+  assert.equal(handlerInfos.length, 2);
+  assert.ok(handlerInfos[0] !== startingHandlerInfo, "The starting foo resolved handlerInfo was overridden because the new had different params");
+  assert.ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
+  assertHandlerEquals(assert, handlerInfos[1], handlers.comments);
 });
 
-test("URLTransitionIntent applied to an already-resolved handlerInfo of different route", function() {
+test("URLTransitionIntent applied to an already-resolved handlerInfo of different route", function(assert) {
   var state = new TransitionState();
 
   var startingHandlerInfo = new ResolvedHandlerInfo({
@@ -205,13 +205,13 @@ test("URLTransitionIntent applied to an already-resolved handlerInfo of differen
   var newState = intent.applyToState(state, recognizer, scenario.getHandler);
   var handlerInfos = newState.handlerInfos;
 
-  equal(handlerInfos.length, 2);
-  ok(handlerInfos[0] !== startingHandlerInfo, "The starting foo resolved handlerInfo gets overridden because the new one has a different name");
-  ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
-  assertHandlerEquals(handlerInfos[1], handlers.bar);
+  assert.equal(handlerInfos.length, 2);
+  assert.ok(handlerInfos[0] !== startingHandlerInfo, "The starting foo resolved handlerInfo gets overridden because the new one has a different name");
+  assert.ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByParam, "generated state consists of UnresolvedHandlerInfoByParam, 2");
+  assertHandlerEquals(assert, handlerInfos[1], handlers.bar);
 });
 
-test("NamedTransitionIntent applied to an already-resolved handlerInfo (non-empty params)", function() {
+test("NamedTransitionIntent applied to an already-resolved handlerInfo (non-empty params)", function(assert) {
   var state = new TransitionState();
 
   var article = {};
@@ -234,12 +234,12 @@ test("NamedTransitionIntent applied to an already-resolved handlerInfo (non-empt
   var newState = intent.applyToState(state, recognizer, scenario.getHandler, null, scenario.getSerializer);
   var handlerInfos = newState.handlerInfos;
 
-  equal(handlerInfos.length, 2);
-  equal(handlerInfos[0], startingHandlerInfo);
-  equal(handlerInfos[0].context, article);
-  ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByObject, "generated state consists of UnresolvedHandlerInfoByObject, 2");
-  equal(handlerInfos[1].context, comment);
-  assertHandlerEquals(handlerInfos[1], handlers.comments);
+  assert.equal(handlerInfos.length, 2);
+  assert.equal(handlerInfos[0], startingHandlerInfo);
+  assert.equal(handlerInfos[0].context, article);
+  assert.ok(handlerInfos[1] instanceof UnresolvedHandlerInfoByObject, "generated state consists of UnresolvedHandlerInfoByObject, 2");
+  assert.equal(handlerInfos[1].context, comment);
+  assertHandlerEquals(assert, handlerInfos[1], handlers.comments);
 });
 
 });

--- a/test/tests/transition_state_test.js
+++ b/test/tests/transition_state_test.js
@@ -1,4 +1,4 @@
-import { module, flushBackburner, stubbedHandlerInfoFactory } from "tests/test_helpers";
+import { module, test, flushBackburner, stubbedHandlerInfoFactory } from "tests/test_helpers";
 import TransitionState from 'router/transition-state';
 
 import UnresolvedHandlerInfoByObject from 'router/handler-info/unresolved-handler-info-by-object';
@@ -8,14 +8,13 @@ import { resolve, reject } from "rsvp";
 
 module("TransitionState");
 
-test("it starts off with default state", function() {
+test("it starts off with default state", function(assert) {
   var state = new TransitionState();
-  deepEqual(state.handlerInfos, [], "it has an array of handlerInfos");
+  assert.deepEqual(state.handlerInfos, [], "it has an array of handlerInfos");
 });
 
-test("#resolve delegates to handleInfo objects' resolve()", function() {
-
-  expect(8);
+test("#resolve delegates to handleInfo objects' resolve()", function(assert) {
+  assert.expect(8);
 
   var state = new TransitionState();
 
@@ -27,7 +26,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function() {
     {
       resolve: function(shouldContinue) {
         ++counter;
-        equal(counter, 1);
+        assert.equal(counter, 1);
         shouldContinue();
         return resolve(resolvedHandlerInfos[0]);
       }
@@ -35,7 +34,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function() {
     {
       resolve: function(shouldContinue) {
         ++counter;
-        equal(counter, 2);
+        assert.equal(counter, 2);
         shouldContinue();
         return resolve(resolvedHandlerInfos[1]);
       }
@@ -43,18 +42,17 @@ test("#resolve delegates to handleInfo objects' resolve()", function() {
   ];
 
   function keepGoing() {
-    ok(true, "continuation function was called");
+    assert.ok(true, "continuation function was called");
   }
 
   state.resolve(keepGoing).then(function(result) {
-    ok(!result.error);
-    deepEqual(result.state.handlerInfos, resolvedHandlerInfos);
+    assert.notOk(result.error);
+    assert.deepEqual(result.state.handlerInfos, resolvedHandlerInfos);
   });
 });
 
-test("State resolution can be halted", function() {
-
-  expect(2);
+test("State resolution can be halted", function(assert) {
+  assert.expect(2);
 
   var state = new TransitionState();
 
@@ -66,7 +64,7 @@ test("State resolution can be halted", function() {
     },
     {
       resolve: function() {
-        ok(false, "I should not be entered because we threw an error in shouldContinue");
+        assert.ok(false, "I should not be entered because we threw an error in shouldContinue");
       }
     }
   ];
@@ -76,17 +74,16 @@ test("State resolution can be halted", function() {
   }
 
   state.resolve(keepGoing).catch(function(reason) {
-    equal(reason.error, "NOPE");
-    ok(reason.wasAborted, "state resolution was correctly marked as aborted");
+    assert.equal(reason.error, "NOPE");
+    assert.ok(reason.wasAborted, "state resolution was correctly marked as aborted");
   });
 
   flushBackburner();
 });
 
 
-test("Integration w/ HandlerInfos", function() {
-
-  expect(5);
+test("Integration w/ HandlerInfos", function(assert) {
+  assert.expect(5);
 
   var state = new TransitionState();
 
@@ -100,8 +97,8 @@ test("Integration w/ HandlerInfos", function() {
       params: { foo_id: '123' },
       handler: {
         model: function(params, payload) {
-          equal(payload, transition);
-          equal(params.foo_id, '123', "foo#model received expected params");
+          assert.equal(payload, transition);
+          assert.equal(params.foo_id, '123', "foo#model received expected params");
           return resolve(fooModel);
         }
       },
@@ -124,11 +121,11 @@ test("Integration w/ HandlerInfos", function() {
       models.push(result.state.handlerInfos[i].context);
     }
 
-    ok(!result.error);
-    equal(models[0], fooModel);
-    equal(models[1], barModel);
+    assert.notOk(result.error);
+    assert.equal(models[0], fooModel);
+    assert.equal(models[1], barModel);
   }).catch(function(error){
-    ok(false, "Caught error: "+error);
+    assert.ok(false, "Caught error: "+error);
   });
 });
 

--- a/test/tests/unrecognized-url-error_test.js
+++ b/test/tests/unrecognized-url-error_test.js
@@ -1,15 +1,17 @@
+import { module, test } from './test_helpers';
 import UnrecognizedURLError from 'router/unrecognized-url-error';
 
 module("unrecognized-url-error");
 
-test("correct inheritance", function() {
+test("correct inheritance", function(assert) {
   var error;
+
   try {
     throw new UnrecognizedURLError('Message');
   } catch(e) {
     error = e;
   }
 
-  ok(error instanceof UnrecognizedURLError);
-  ok(error instanceof Error);
+  assert.ok(error instanceof UnrecognizedURLError);
+  assert.ok(error instanceof Error);
 });

--- a/test/tests/utils_test.js
+++ b/test/tests/utils_test.js
@@ -1,47 +1,48 @@
+import { module, test } from './test_helpers';
 import { getChangelist, callHook } from 'router/utils';
 
 module("utils");
 
-test("getChangelist", function() {
+test("getChangelist", function(assert) {
   var result = getChangelist({}, { foo: '123' });
-  deepEqual(result, { all: { foo: '123' }, changed: { foo: '123' }, removed: {} });
+  assert.deepEqual(result, { all: { foo: '123' }, changed: { foo: '123' }, removed: {} });
 
   result = getChangelist({ foo: '123' }, { foo: '123' });
-  ok(!result);
+  assert.notOk(result);
 
   result = getChangelist({ foo: '123' }, {});
-  deepEqual(result, { all: {}, changed: {}, removed: { foo: '123' } });
+  assert.deepEqual(result, { all: {}, changed: {}, removed: { foo: '123' } });
 
   result = getChangelist({ foo: '123', bar: '456'}, { foo: '123'});
-  deepEqual(result, { all: { foo: '123' }, changed: {}, removed: { bar: '456' } });
+  assert.deepEqual(result, { all: { foo: '123' }, changed: {}, removed: { bar: '456' } });
 
   result = getChangelist({ foo: '123', bar: '456'}, { foo: '456'});
-  deepEqual(result, { all: { foo: '456' }, changed: { foo: '456' }, removed: { bar: '456' } });
+  assert.deepEqual(result, { all: { foo: '456' }, changed: { foo: '456' }, removed: { bar: '456' } });
 });
 
-test("callHook invokes optional methods, preferring underscored versions", function() {
-  expect(8);
+test("callHook invokes optional methods, preferring underscored versions", function(assert) {
+  assert.expect(8);
 
   var obj = {
     a: function(a, b) {
-      equal(a, 1);
-      equal(b, 2);
-      equal(this, obj);
-      ok(true);
+      assert.equal(a, 1);
+      assert.equal(b, 2);
+      assert.equal(this, obj);
+      assert.ok(true);
       return "A";
     },
     _b: function() {
-      ok(true);
+      assert.ok(true);
       return "B";
     },
     b: function() {
-      ok(false, "b shouldn't be called");
+      assert.ok(false, "b shouldn't be called");
     }
   };
 
-  equal("A", callHook(obj, 'a', 1, 2, 3));
-  equal("B", callHook(obj, 'b'));
-  ok(typeof callHook(obj, 'c'), 'undefined');
+  assert.equal("A", callHook(obj, 'a', 1, 2, 3));
+  assert.equal("B", callHook(obj, 'b'));
+  assert.ok(typeof callHook(obj, 'c'), 'undefined');
   callHook(null, "wat");
 });
 


### PR DESCRIPTION
Step 3 in improving test help.

The number of allowed globals was too high. In particular, the tests all used the QUnit globals which have been deprecated and removed in 2.x. This helps keep tests more atomic.

Remaining piece after this will be to extract the pseudo-async backburner logic to give better guarantees about testing actually async behavior.