### PR TITLE
Use Object.defineProperty over getter/setter also for handlerPromise

### DIFF
--- a/lib/router/handler-info.js
+++ b/lib/router/handler-info.js
@@ -56,20 +56,6 @@ HandlerInfo.prototype = {
 
   _handlerPromise: undefined,
 
-  get handlerPromise() {
-    if (this._handlerPromise) {
-      return this._handlerPromise;
-    }
-
-    this.fetchHandler();
-
-    return this._handlerPromise;
-  },
-
-  set handlerPromise(handlerPromise) {
-    return this._handlerPromise = handlerPromise;
-  },
-
   params: null,
   context: null,
 
@@ -233,6 +219,21 @@ Object.defineProperty(HandlerInfo.prototype, 'handler', {
   }
 });
 
+Object.defineProperty(HandlerInfo.prototype, 'handlerPromise', {
+  get: function() {
+    if (this._handlerPromise) {
+      return this._handlerPromise;
+    }
+
+    this.fetchHandler();
+
+    return this._handlerPromise;
+  },
+
+  set: function(handlerPromise) {
+    return this._handlerPromise = handlerPromise;
+  }
+});
 
 function paramsMatch(a, b) {
   if ((!a) ^ (!b)) {


### PR DESCRIPTION
@rwjblue I think your PR #189 missed the `handlerPromise` property. Was still getting a PhantomJS crash as reported in #188 , even with the lastest canary build. This should hopefully fix it! :)