### PR TITLE
Document `Transition#isExiting` as public

### DIFF
--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -95,6 +95,16 @@ Transition.prototype = {
 
   isTransition: true,
 
+  /**
+    Check whether this transition is exiting the given `handler`.
+    The `handler` argument can be the the handler object itself or the name
+    of the handler.
+
+    @method isExiting
+    @param {String|Object} handler The handler's name or object.
+    @return {Boolean}
+    @public
+  */
   isExiting: function(handler) {
     var handlerInfos = this.handlerInfos;
     for (var i = 0, len = handlerInfos.length; i < len; ++i) {


### PR DESCRIPTION
It appears as though the `Transition#isExiting` is intended to be public. This PR marks it as public, adds documentation for it, and adds tests for the `isExiting` method with both string and handler-object arguments for transitions between sibling and nested routes. Previously there were only a few tests that passed handler objects to `isExiting` and none that passed handler names (strings).
