### PR TITLE
Fix queryParamsOnly being correct on transitions.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -45,6 +45,7 @@ function getTransitionByIntent(intent, isIntermediate) {
     if (queryParamChangelist) {
       newTransition = this.queryParamsTransition(queryParamChangelist, wasTransitioning, oldState, newState);
       if (newTransition) {
+        newTransition.queryParamsOnly = true;
         return newTransition;
       }
     }
@@ -60,6 +61,12 @@ function getTransitionByIntent(intent, isIntermediate) {
 
   // Create a new transition to the destination route.
   newTransition = new Transition(this, intent, newState);
+
+  // transition is to same route with same params, only query params differ.
+  // not caught above probably because refresh() has been used
+  if (  handlerInfosSameExceptQueryParams(newState.handlerInfos, oldState.handlerInfos ) ) {
+    newTransition.queryParamsOnly = true;
+  }
 
   // Abort and usurp any previously active transition.
   if (this.activeTransition) {
@@ -748,6 +755,50 @@ function handlerInfosEqual(handlerInfos, otherHandlerInfos) {
     }
   }
   return true;
+}
+
+function handlerInfosSameExceptQueryParams(handlerInfos, otherHandlerInfos) {
+  if (handlerInfos.length !== otherHandlerInfos.length) {
+    return false;
+  }
+
+  for (var i = 0, len = handlerInfos.length; i < len; ++i) {
+    if (handlerInfos[i].name !== otherHandlerInfos[i].name) {
+      return false;
+    }
+
+    if (!paramsEqual(handlerInfos[i].params, otherHandlerInfos[i].params)) {
+      return false;
+    }
+  }
+  return true;
+
+}
+
+function paramsEqual(params, otherParams) {
+  if (!params && !otherParams) {
+    return true;
+  } else if (!params && !!otherParams || !!params && !otherParams) {
+    // one is falsy but other is not;
+    return false;
+  }
+  var keys        = Object.keys(params);
+  var otherKeys   = Object.keys(otherParams);
+
+  if (keys.length !== otherKeys.length) {
+    return false;
+  }
+
+  for (var i = 0, len = keys.length; i < len; ++i) {
+    var key = keys[i];
+
+    if ( params[key] !== otherParams[key] ) {
+      return false;
+    }
+  }
+
+  return true;
+
 }
 
 function finalizeQueryParamChange(router, resolvedHandlers, newQueryParams, transition) {


### PR DESCRIPTION
This property has been set incorrectly on some transitions, notably when the
transition is caused by the Router#refresh() method in queryParamsDidChange.

This is the method ember uses to implement `refreshModel` option of query params,
so fixing this bug allows `refreshModel` to be used in conjunction with
`replace` option for query params, currently it is either-or.

Resolves emberjs/ember.js#10577 and emberjs/ember.js#11843
