### PR TITLE
Improve errors

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -2,7 +2,8 @@ import RouteRecognizer from 'route-recognizer';
 import { Promise } from 'rsvp';
 import { trigger, log, slice, forEach, merge, extractQueryParams, getChangelist, promiseLabel, callHook } from './utils';
 import TransitionState from './transition-state';
-import { logAbort, Transition, TransitionAborted } from './transition';
+import { logAbort, Transition } from './transition';
+import TransitionAbortedError from './transition-aborted-error';
 import NamedTransitionIntent from './transition-intent/named-transition-intent';
 import URLTransitionIntent from './transition-intent/url-transition-intent';
 
@@ -494,7 +495,7 @@ function handlerEnteredOrUpdated(currentHandlerInfos, handlerInfo, enter, transi
     }
 
     if (transition && transition.isAborted) {
-      throw new TransitionAborted();
+      throw new TransitionAbortedError();
     }
 
     handler.context = context;
@@ -502,7 +503,7 @@ function handlerEnteredOrUpdated(currentHandlerInfos, handlerInfo, enter, transi
 
     callHook(handler, 'setup', context, transition);
     if (transition && transition.isAborted) {
-      throw new TransitionAborted();
+      throw new TransitionAbortedError();
     }
 
     currentHandlerInfos.push(handlerInfo);
@@ -694,7 +695,7 @@ function finalizeTransition(transition, newState) {
     // Resolve with the final handler.
     return handlerInfos[handlerInfos.length - 1].handler;
   } catch(e) {
-    if (!(e instanceof TransitionAborted)) {
+    if (!(e instanceof TransitionAbortedError)) {
       //var erroneousHandler = handlerInfos.pop();
       var infos = transition.state.handlerInfos;
       transition.trigger(true, 'error', e, transition, infos[infos.length-1].handler);

--- a/lib/router/transition-aborted-error.js
+++ b/lib/router/transition-aborted-error.js
@@ -1,0 +1,27 @@
+import { oCreate } from './utils';
+
+function TransitionAbortedError(message) {
+  if (!(this instanceof TransitionAbortedError)) {
+    return new TransitionAbortedError(message);
+  }
+
+  let error = Error.call(this, message);
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, TransitionAbortedError);
+  } else {
+    this.stack = error.stack;
+  }
+
+  this.description = error.description;
+  this.fileName = error.fileName;
+  this.lineNumber = error.lineNumber;
+  this.message = error.message || 'TransitionAborted';
+  this.name = 'TransitionAborted';
+  this.number = error.number;
+  this.code = error.code;
+}
+
+TransitionAbortedError.prototype = oCreate(Error.prototype);
+
+export default TransitionAbortedError;

--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -1,5 +1,6 @@
 import { Promise } from 'rsvp';
 import { trigger, slice, log, promiseLabel } from './utils';
+import TransitionAbortedError from './transition-aborted-error';
 
 /**
   A Transition is a thennable (a promise-like object) that represents
@@ -325,16 +326,11 @@ Transition.prototype.send = Transition.prototype.trigger;
 /**
   @private
 
-  Logs and returns a TransitionAborted error.
+  Logs and returns an instance of TransitionAbortedError.
  */
 function logAbort(transition) {
   log(transition.router, transition.sequence, "detected abort.");
-  return new TransitionAborted();
+  return new TransitionAbortedError();
 }
 
-function TransitionAborted(message) {
-  this.message = (message || "TransitionAborted");
-  this.name = "TransitionAborted";
-}
-
-export { Transition, logAbort, TransitionAborted };
+export { Transition, logAbort, TransitionAbortedError as TransitionAborted };

--- a/lib/router/unrecognized-url-error.js
+++ b/lib/router/unrecognized-url-error.js
@@ -1,13 +1,25 @@
 import { oCreate } from './utils';
 
-/**
-  Promise reject reasons passed to promise rejection
-  handlers for failed transitions.
- */
 function UnrecognizedURLError(message) {
-  this.message = (message || "UnrecognizedURLError");
-  this.name = "UnrecognizedURLError";
-  Error.call(this);
+  if (!(this instanceof UnrecognizedURLError)) {
+    return new UnrecognizedURLError(message);
+  }
+
+  let error = Error.call(this, message);
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, UnrecognizedURLError);
+  } else {
+    this.stack = error.stack;
+  }
+
+  this.description = error.description;
+  this.fileName = error.fileName;
+  this.lineNumber = error.lineNumber;
+  this.message = error.message || 'UnrecognizedURL';
+  this.name = 'UnrecognizedURLError';
+  this.number = error.number;
+  this.code = error.code;
 }
 
 UnrecognizedURLError.prototype = oCreate(Error.prototype);

--- a/test/tests/router_test.js
+++ b/test/tests/router_test.js
@@ -1,4 +1,12 @@
-import { module, test, flushBackburner, transitionTo, transitionToWithAbort,  shouldNotHappen } from "tests/test_helpers";
+import {
+  module,
+  test,
+  flushBackburner,
+  transitionTo,
+  transitionToWithAbort,
+  shouldNotHappen,
+  assertAbort
+} from 'tests/test_helpers';
 import Router from "router";
 import { reject, Promise } from "rsvp";
 
@@ -1715,12 +1723,6 @@ test("can redirect from error handler", function(assert) {
   });
 });
 
-function assertAbort(assert) {
-  return function _assertAbort(e) {
-    assert.equal(e.name, "TransitionAborted", "transition was aborted");
-  };
-}
-
 test("can redirect from setup/enter", function(assert) {
   assert.expect(5);
 
@@ -1967,9 +1969,7 @@ test("willTransition function fired with cancellable transition passed in", func
       transition.abort();
     };
 
-    return router.transitionTo('about').then(shouldNotHappen(assert), function(e) {
-      assert.equal(e.name, 'TransitionAborted', 'reject object is a TransitionAborted');
-    });
+    return router.transitionTo('about').then(shouldNotHappen(assert), assertAbort(assert));
   });
 });
 
@@ -1996,9 +1996,7 @@ test("transitions can be aborted in the willTransition event", function(assert) 
   };
 
   router.handleURL('/index').then(function() {
-    return router.transitionTo('about').then(shouldNotHappen(assert), function(e) {
-      assert.equal(e.name, 'TransitionAborted', 'reject object is a TransitionAborted');
-    });
+    return router.transitionTo('about').then(shouldNotHappen(assert), assertAbort(assert));
   });
 });
 

--- a/test/tests/transition-aborted-error_test.js
+++ b/test/tests/transition-aborted-error_test.js
@@ -1,0 +1,20 @@
+import { module, test } from './test_helpers';
+import TransitionAbortedError from 'router/transition-aborted-error';
+
+module('transition-aborted-error');
+
+test('correct inheritance and name', function(assert) {
+  var error;
+
+  try {
+    throw new TransitionAbortedError('Message');
+  } catch(e) {
+    error = e;
+  }
+
+  // it would be more correct with TransitionAbortedError, but other libraries may rely on this name
+  assert.equal(error.name, 'TransitionAborted', "TransitionAbortedError has the name 'TransitionAborted'");
+
+  assert.ok(error instanceof TransitionAbortedError);
+  assert.ok(error instanceof Error);
+});


### PR DESCRIPTION
@rwjblue how does this look?

- Inherit from `Error`
- Cleanup tests to use a shared helper
- Test to ensure that TransitionAbortedError has the correct name
- Improve stacktrace capturing

fixes #174 
