### PR TITLE
Fix query params refresh transitions if they are using replaceState

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -245,7 +245,8 @@ Router.prototype = {
   },
 
   refresh: function(pivotHandler) {
-    var state = this.activeTransition ? this.activeTransition.state : this.state;
+    var previousTransition = this.activeTransition;
+    var state = previousTransition ? previousTransition.state : this.state;
     var handlerInfos = state.handlerInfos;
     var params = {};
     for (var i = 0, len = handlerInfos.length; i < len; ++i) {
@@ -261,7 +262,14 @@ Router.prototype = {
       queryParams: this._changedQueryParams || state.queryParams || {}
     });
 
-    return this.transitionByIntent(intent, false);
+    var newTransition = this.transitionByIntent(intent, false);
+
+    // if the previous transition is a replace transition, that needs to be preserved
+    if (previousTransition && previousTransition.urlMethod === 'replace') {
+      newTransition.method(previousTransition.urlMethod);
+    }
+
+    return newTransition;
   },
 
   /**
@@ -654,7 +662,15 @@ function updateURL(transition, state/*, inputUrl*/) {
       !transition.isCausedByAbortingTransition
     );
 
-    if (initial || replaceAndNotAborting) {
+    // because calling refresh causes an aborted transition, this needs to be
+    // special cased - if the initial transition is a replace transition, the
+    // urlMethod should be honored here.
+    var isQueryParamsRefreshTransition = (
+      transition.queryParamsOnly &&
+      urlMethod === 'replace'
+    );
+
+    if (initial || replaceAndNotAborting || isQueryParamsRefreshTransition) {
       router.replaceURL(url);
     } else {
       router.updateURL(url);

--- a/test/tests/query_params_test.js
+++ b/test/tests/query_params_test.js
@@ -159,9 +159,21 @@ test("transitioning between routes fires a queryParamsDidChange event", function
 
 
 test("Refreshing the route when changing only query params should correctly set queryParamsOnly", function(assert) {
-  assert.expect(10);
+  assert.expect(16);
 
   var initialTransition = true;
+
+  var expectReplace;
+
+  router.updateURL = function(newUrl) {
+    assert.notOk(expectReplace, "Expected replace but update was called");
+    url = newUrl;
+  };
+
+  router.replaceURL = function(newUrl) {
+    assert.ok(expectReplace, "Replace was called but update was expected");
+    url = newUrl;
+  };
 
   handlers.index = {
     events: {
@@ -189,6 +201,8 @@ test("Refreshing the route when changing only query params should correctly set 
     }
   };
 
+  expectReplace = false;
+
   var transition = transitionTo(router, '/index');
   assert.notOk(transition.queryParamsOnly, "Initial transition is not query params only transition");
 
@@ -196,11 +210,12 @@ test("Refreshing the route when changing only query params should correctly set 
 
   assert.ok(transition.queryParamsOnly, "Second transition with updateURL intent is query params only");
 
+  expectReplace = true;
   transition = router.replaceWith('/index?foo=456');
   flushBackburner();
 
   assert.ok(transition.queryParamsOnly, "Third transition with replaceURL intent is query params only");
-
+  expectReplace = false;
 
   transition = transitionTo(router, '/parent/child?foo=789');
   assert.notOk(transition.queryParamsOnly, "Fourth transition with transtionTo intent is not query params only");


### PR DESCRIPTION
So I fixed this in #198. But it was broken again by #197 and the tests didn't
catch that. So I've improved the tests and fixed it again.

@rwjblue I think you were looking at this last time

Ember issue: emberjs/ember.js#11843
Ember failing test PR: emberjs/ember.js#15148
