### PR TITLE
If a transition initiated with `replaceWith`, it's retry is also a replace.

### DIFF
--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -234,7 +234,9 @@ Transition.prototype = {
   retry: function() {
     // TODO: add tests for merged state retry()s
     this.abort();
-    return this.router.transitionByIntent(this.intent, false);
+    var newTransition = this.router.transitionByIntent(this.intent, false);
+    newTransition.method(this.urlMethod);
+    return newTransition;
   },
 
   /**


### PR DESCRIPTION
Prior to this change retrying the transition would convert the `replaceWith` in
a regular `transitionTo`.

Example code (assuming `this` is an Ember route):
```js
let transition = this.replaceWith('new.route');
transition.abort();
session.set('attemptedTransition', transition);
session.authenticate('authenticator:devise').authenticate(username, password); // Successful authentication will call `session.get('attemptedTransition').retry()`
```