### PR TITLE
Ensure initial transition can be aborted then retried.

### DIFF
--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -235,7 +235,18 @@ Transition.prototype = {
     // TODO: add tests for merged state retry()s
     this.abort();
     var newTransition = this.router.transitionByIntent(this.intent, false);
-    newTransition.method(this.urlMethod);
+
+    // inheriting a `null` urlMethod is not valid
+    // the urlMethod is only set to `null` when
+    // the transition is initiated *after* the url
+    // has been updated (i.e. `router.handleURL`)
+    //
+    // in that scenario, the url method cannot be
+    // inherited for a new transition because then
+    // the url would not update even though it should
+    if (this.urlMethod !== null) {
+      newTransition.method(this.urlMethod);
+    }
     return newTransition;
   },
 

--- a/test/tests/test_helpers.js
+++ b/test/tests/test_helpers.js
@@ -61,10 +61,18 @@ function transitionToWithAbort(assert, router) {
   flushBackburner();
 }
 
-function shouldNotHappen(assert) {
+function handleURL(router) {
+  var result = router.handleURL.apply(router, slice.call(arguments, 1));
+  flushBackburner();
+  return result;
+}
+
+
+function shouldNotHappen(assert, _message) {
+  var message = _message || "this .then handler should not be called";
   return function _shouldNotHappen(error) {
     console.error(error.stack); // jshint ignore:line
-    assert.ok(false, "this .then handler should not be called");
+    assert.ok(false, message);
   };
 }
 
@@ -87,6 +95,7 @@ export {
   module,
   test,
   flushBackburner,
+  handleURL,
   transitionTo,
   transitionToWithAbort,
   shouldNotHappen,


### PR DESCRIPTION
Attempting to recreate the scenario identified in https://github.com/emberjs/ember.js/issues/15190.