### PR TITLE
Bind the serialize handler to the correct "this"

### DIFF
--- a/lib/router/handler-info/unresolved-handler-info-by-object.js
+++ b/lib/router/handler-info/unresolved-handler-info-by-object.js
@@ -24,8 +24,7 @@ var UnresolvedHandlerInfoByObject = subclass(HandlerInfo, {
   */
   serialize: function(_model) {
     var model = _model || this.context,
-      names = this.names,
-      serializer = this.serializer || (this.handler && this.handler.serialize);
+      names = this.names;
 
     var object = {};
     if (isParam(model)) {
@@ -34,8 +33,11 @@ var UnresolvedHandlerInfoByObject = subclass(HandlerInfo, {
     }
 
     // Use custom serialize if it exists.
-    if (serializer) {
-      return serializer(model, names);
+    if (this.serializer) {
+      // invoke this.serializer unbound (getSerializer returns a stateless function)
+      return this.serializer.call(null, model, names);
+    } else if (this.handler && this.handler.serialize) {
+      return this.handler.serialize(model, names);
     }
 
     if (names.length !== 1) {

--- a/tests/router_test.js
+++ b/tests/router_test.js
@@ -1491,6 +1491,22 @@ scenarios.forEach(function(scenario) {
     );
   });
 
+  test('the serializer method is unbound', function(assert) {
+    assert.expect(1);
+
+    router.getSerializer = function() {
+      return function(date) {
+        assert.equal(this, undefined);
+        return {
+          date:
+            date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate(),
+        };
+      };
+    };
+
+    router.generate('showPostsForDate', new Date(1815, 5, 18));
+  });
+
   test('params are known by a transition up front', function(assert) {
     assert.expect(2);
 

--- a/tests/router_test.js
+++ b/tests/router_test.js
@@ -2925,6 +2925,26 @@ scenarios.forEach(function(scenario) {
       });
   });
 
+  test('the serialize function is bound to the correct object when called', function(
+    assert
+  ) {
+    assert.expect(scenario.async ? 0 : 1);
+
+    handlers = {
+      showPostsForDate: {
+        serialize: function(date) {
+          assert.equal(this, handlers.showPostsForDate);
+          return {
+            date:
+              date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate(),
+          };
+        },
+      },
+    };
+
+    router.generate('showPostsForDate', new Date(1815, 5, 18));
+  });
+
   test('transitionTo will soak up resolved parent models of active transition', function(
     assert
   ) {


### PR DESCRIPTION
I hit this issue in an Ember application where `this` in the `serialize` hook inside a router was undefined. I guess this is a bug.

Not sure whether the same should be done for `this.serializer` on the line that I've changed. I'm also not sure that I've handled the `async` case in the tests correctly - I just ignore it.

I'm willing to fix anything that you don't like in this PR. :)