### PR TITLE
using `Object.create(null)` for resolvedModels

### DIFF
--- a/lib/router/handler-info.js
+++ b/lib/router/handler-info.js
@@ -166,7 +166,7 @@ HandlerInfo.prototype = {
   },
 
   stashResolvedModel: function(payload, resolvedModel) {
-    payload.resolvedModels = payload.resolvedModels || {};
+    payload.resolvedModels = payload.resolvedModels || Object.create(null);
     payload.resolvedModels[this.name] = resolvedModel;
   },
 

--- a/lib/router/transition.js
+++ b/lib/router/transition.js
@@ -23,7 +23,7 @@ function Transition(router, intent, state, error, previousTransition) {
   this.intent = intent;
   this.router = router;
   this.data = this.intent && this.intent.data || {};
-  this.resolvedModels = {};
+  this.resolvedModels = Object.create(null);
   this.queryParams = {};
   this.promise = undefined;
   this.error = undefined;
@@ -73,7 +73,8 @@ function Transition(router, intent, state, error, previousTransition) {
 
     this.sequence = router.currentSequence++;
     this.promise = state.resolve(checkForAbort, this)['catch'](
-      catchHandlerForTransition(transition), promiseLabel('Handle Abort'));
+      catchHandlerForTransition(transition), promiseLabel('Handle Abort')
+    );
   } else {
     this.promise = Promise.resolve(this.state);
     this.params = {};


### PR DESCRIPTION
will make corresponding changes to ember.js once merged like removing `transition.resolvedModels.hasOwnProperty`