### PR TITLE
Unify HanlderInfo#handler setup.

### DIFF
--- a/lib/router/handler-info.js
+++ b/lib/router/handler-info.js
@@ -1,4 +1,4 @@
-import { merge, promiseLabel, applyHook, isPromise } from './utils';
+import { promiseLabel, applyHook, isPromise } from './utils';
 import { Promise } from 'rsvp';
 
 var DEFAULT_HANDLER = Object.freeze({});
@@ -11,27 +11,15 @@ export default class HandlerInfo {
     this._handler = DEFAULT_HANDLER;
     this._handlerPromise = null;
     this.factory = null; // Injected by the handler info factory
+    this.name = props.name;
 
-    if (props.handler) {
-      var name = props.name;
-
-      // Setup a handlerPromise so that we can wait for asynchronously loaded handlers
-      this.handlerPromise = Promise.resolve(props.handler);
-
-      // Wait until the 'handler' property has been updated when chaining to a handler
-      // that is a promise
-      if (isPromise(props.handler)) {
-        this.handlerPromise = this.handlerPromise.then(
-          this.updateHandler.bind(this)
-        );
-        props.handler = undefined;
-      } else if (props.handler) {
-        // Store the name of the handler on the handler for easy checks later
-        props.handler._handlerName = name;
+    for (let prop in props) {
+      if (prop === 'handler') {
+        this._processHandler(props.handler);
+      } else {
+        this[prop] = props[prop];
       }
     }
-
-    merge(this, props);
   }
 
   getHandler() {}
@@ -39,22 +27,24 @@ export default class HandlerInfo {
   fetchHandler() {
     var handler = this.getHandler(this.name);
 
+    return this._processHandler(handler);
+  }
+
+  _processHandler(handler) {
     // Setup a handlerPromise so that we can wait for asynchronously loaded handlers
     this.handlerPromise = Promise.resolve(handler);
 
     // Wait until the 'handler' property has been updated when chaining to a handler
     // that is a promise
     if (isPromise(handler)) {
-      this.handlerPromise = this.handlerPromise.then(
-        this.updateHandler.bind(this)
-      );
+      this.handlerPromise = this.handlerPromise.then(h => {
+        return this.updateHandler(h);
+      });
+      // set to undefined to avoid recursive loop in the handler getter
+      return (this.handler = undefined);
     } else if (handler) {
-      // Store the name of the handler on the handler for easy checks later
-      handler._handlerName = this.name;
-      return (this.handler = handler);
+      return this.updateHandler(handler);
     }
-
-    return (this.handler = undefined);
   }
 
   log(payload, message) {


### PR DESCRIPTION
Previously, we had nearly identical logic in the `constructor` and `fetchHandler` methods. This refactor extracts a `_processHandler` method that both can use and ensures that all setup goes through the same pathway.