### PR TITLE
Fix a crash when (hash) helper is used to create queryParams object

### DIFF
--- a/lib/router/utils.js
+++ b/lib/router/utils.js
@@ -33,7 +33,7 @@ export function extractQueryParams(array) {
     len &&
     len > 0 &&
     array[len - 1] &&
-    array[len - 1].hasOwnProperty('queryParams')
+    hasOwnProperty.call(array[len - 1], 'queryParams')
   ) {
     queryParams = array[len - 1].queryParams;
     head = slice.call(array, 0, len - 1);


### PR DESCRIPTION
fix `{{url-for 'posts' (hash queryParams=paramsHash)}}` use case