### PR TITLE
[BREAKING] Router Abstract Base class

### DIFF
--- a/lib/router/handler-info.ts
+++ b/lib/router/handler-info.ts
@@ -410,7 +410,7 @@ export class UnresolvedHandlerInfoByObject extends HandlerInfo {
     name: string,
     names: string[],
     getHandler: GetHandlerFunc,
-    serializer: SerializerFunc,
+    serializer: SerializerFunc | undefined,
     context: Dict<unknown>
   ) {
     super(name);

--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -1,3 +1,4 @@
 export { default } from './router';
 export { Transition } from './transition';
+export { default as TransitionState } from './transition-state';
 export { IHandler } from './handler-info';

--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -275,9 +275,9 @@ export default abstract class Router {
     let state = intent.applyToState(
       this.state!,
       this.recognizer,
-      this.getHandler,
+      this.getHandler.bind(this),
       false,
-      this.getSerializer
+      this.getSerializer.bind(this)
     );
 
     let params: Params = {};
@@ -296,7 +296,13 @@ export default abstract class Router {
 
     let state = (this.activeTransition && this.activeTransition.state) || this.state!;
 
-    return intent.applyToState(state, this.recognizer, this.getHandler, false, this.getSerializer);
+    return intent.applyToState(
+      state,
+      this.recognizer,
+      this.getHandler.bind(this),
+      false,
+      this.getSerializer
+    );
   }
 
   isActiveIntent(
@@ -339,11 +345,11 @@ export default abstract class Router {
     let newState = intent.applyToHandlers(
       testState,
       recogHandlers,
-      this.getHandler,
+      this.getHandler.bind(this),
       targetHandler,
       true,
       true,
-      this.getSerializer
+      this.getSerializer.bind(this)
     );
 
     let handlersEqual = handlerInfosEqual(newState.handlerInfos, testState.handlerInfos);
@@ -383,9 +389,9 @@ function getTransitionByIntent(this: Router, intent: TransitionIntent, isInterme
   let newState = intent.applyToState(
     oldState!,
     this.recognizer,
-    this.getHandler,
+    this.getHandler.bind(this),
     isIntermediate,
-    this.getSerializer
+    this.getSerializer.bind(this)
   );
   let queryParamChangelist = getChangelist(oldState!.queryParams, newState.queryParams);
 

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -186,7 +186,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
     oldHandlerInfo: HandlerInfo,
     _targetRouteName: string,
     i: number,
-    serializer: SerializerFunc
+    serializer?: SerializerFunc
   ) {
     let objectToUse: Dict<unknown>;
     if (objects.length > 0) {

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -5,7 +5,7 @@ import Router from './router';
 import TransitionAborted from './transition-aborted-error';
 import { TransitionIntent } from './transition-intent';
 import TransitionState, { TransitionError } from './transition-state';
-import { log, promiseLabel, trigger } from './utils';
+import { log, promiseLabel } from './utils';
 
 export { default as TransitionAborted } from './transition-aborted-error';
 
@@ -329,13 +329,12 @@ export class Transition {
     @param {String} name the name of the event to fire
     @public
    */
-  trigger(ignoreFailure: boolean, _name: string, ...args: any[]) {
-    trigger(
-      this.router,
+  trigger(ignoreFailure: boolean, name: string, ...args: any[]) {
+    this.router.triggerEvent(
       this.state!.handlerInfos.slice(0, this.resolveIndex + 1),
       ignoreFailure,
-      _name,
-      ...args
+      name,
+      args
     );
   }
 

--- a/tests/async_get_handler_test.ts
+++ b/tests/async_get_handler_test.ts
@@ -13,16 +13,23 @@ QUnit.module('Async Get Handler', {
     QUnit.config.testTimeout = 60000;
 
     handlers = {};
-    router = new Router({
-      getHandler: () => {
+
+    class TestRouter extends Router {
+      didTransition() {}
+      willTransition() {}
+      replaceURL() {}
+      triggerEvent() {}
+      getHandler(_name: string): never {
         throw new Error('never');
-      },
-      delegate: {},
-      getSerializer: () => {
+      }
+
+      getSerializer(_name: string): never {
         throw new Error('never');
-      },
-      updateURL: () => {},
-    });
+      }
+
+      updateURL(_name: string) {}
+    }
+    router = new TestRouter();
     router.map(function(match) {
       match('/index').to('index');
       match('/foo').to('foo', function(match) {

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -3,6 +3,7 @@ import Router, { IHandler, Transition } from 'router';
 import { Dict } from 'router/core';
 import HandlerInfo, { noopGetHandler, UnresolvedHandlerInfoByParam } from 'router/handler-info';
 import TransitionAbortedError from 'router/transition-aborted-error';
+import { UnrecognizedURLError } from 'router/unrecognized-url-error';
 import { configure, resolve } from 'rsvp';
 
 QUnit.config.testTimeout = 1000;
@@ -142,4 +143,50 @@ export function createHandlerInfo(name: string, options: Dict<unknown> = {}): Ha
   Object.assign(Stub.prototype, options);
   let stub = new Stub(name, handler);
   return stub;
+}
+
+export function trigger(
+  handlerInfos: HandlerInfo[],
+  ignoreFailure: boolean,
+  name: string,
+  ...args: any[]
+) {
+  if (!handlerInfos) {
+    if (ignoreFailure) {
+      return;
+    }
+    throw new Error("Could not trigger event '" + name + "'. There are no active handlers");
+  }
+
+  let eventWasHandled = false;
+
+  for (let i = handlerInfos.length - 1; i >= 0; i--) {
+    let currentHandlerInfo = handlerInfos[i],
+      currentHandler = currentHandlerInfo.handler;
+
+    // If there is no handler, it means the handler hasn't resolved yet which
+    // means that we should trigger the event later when the handler is available
+    if (!currentHandler) {
+      currentHandlerInfo.handlerPromise!.then(function(resolvedHandler) {
+        resolvedHandler.events![name].apply(resolvedHandler, args);
+      });
+      continue;
+    }
+
+    if (currentHandler.events && currentHandler.events[name]) {
+      if (currentHandler.events[name].apply(currentHandler, args) === true) {
+        eventWasHandled = true;
+      } else {
+        return;
+      }
+    }
+  }
+
+  // In the case that we got an UnrecognizedURLError as an event with no handler,
+  // let it bubble up
+  if (name === 'error' && (args[0] as UnrecognizedURLError)!.name === 'UnrecognizedURLError') {
+    throw args[0];
+  } else if (!eventWasHandled && !ignoreFailure) {
+    throw new Error("Nothing handled the event '" + name + "'.");
+  }
 }


### PR DESCRIPTION
This moves the Router class to an abstract class and forces the implementation of the following methods:

```ts
  abstract getHandler(name: string): IHandler | Promise<IHandler>;
  abstract getSerializer(name: string): SerializerFunc | undefined;
  abstract updateURL(url: string): void;
  abstract replaceURL(url: string): void;
  abstract willTransition(
    oldHandlerInfos: HandlerInfo[],
    newHandlerInfos: HandlerInfo[],
    transition: Transition
  ): void;
  abstract didTransition(handlerInfos: HandlerInfo[]): void;
  abstract triggerEvent(
    handlerInfos: HandlerInfo[],
    ignoreFailure: boolean,
    name: string,
    args: unknown[]
  ): void;
```

Simultaneously, this removes the fallback behavior if these methods are not implemented. Specifically calls to `trigger` have been completely removed and replaced with just calling the `triggerEvent` method on the router. There is further cleanup in this area that can be done.

This PR also removes the ability to pass a route recognizer delegate.