### PR TITLE
make delegate optional

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -38,7 +38,7 @@ export interface RouterArgs {
   getHandler: GetHandlerFunc;
   getSerializer: GetSerializerFunc;
   updateURL(url: string): void;
-  delegate: Delegate;
+  delegate?: Delegate;
   willTransition?(
     oldHandlerInfos: HandlerInfo[],
     newHandlerInfos: HandlerInfo[],


### PR DESCRIPTION
it seems the typing is wrong. [here the constructor is used without specifying a delegate](https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/routing/lib/system/router.js#L84). This is no code change.