### PR TITLE
Fix types

### DIFF
--- a/lib/router/transition-aborted-error.ts
+++ b/lib/router/transition-aborted-error.ts
@@ -1,9 +1,9 @@
 export interface TransitionAbortedErrorContructor {
-  new (message?: string): TransitionAbortedError;
-  readonly prototype: TransitionAbortedError;
+  new (message?: string): ITransitionAbortedError;
+  readonly prototype: ITransitionAbortedError;
 }
 
-export interface TransitionAbortedError extends Error {
+export interface ITransitionAbortedError extends Error {
   constructor: TransitionAbortedErrorContructor;
 }
 
@@ -11,7 +11,7 @@ const TransitionAbortedError: TransitionAbortedErrorContructor = (function() {
   TransitionAbortedError.prototype = Object.create(Error.prototype);
   TransitionAbortedError.prototype.constructor = TransitionAbortedError;
 
-  function TransitionAbortedError(this: TransitionAbortedError, message?: string) {
+  function TransitionAbortedError(this: ITransitionAbortedError, message?: string) {
     let error = Error.call(this, message);
     this.name = 'TransitionAborted';
     this.message = message || 'TransitionAborted';

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -1,13 +1,20 @@
-import { OnFulfilled, OnRejected, Promise } from 'rsvp';
+import { Promise } from 'rsvp';
 import { Dict, Maybe } from './core';
 import HandlerInfo, { IHandler } from './handler-info';
 import Router from './router';
-import TransitionAborted from './transition-aborted-error';
+import TransitionAborted, { ITransitionAbortedError } from './transition-aborted-error';
 import { TransitionIntent } from './transition-intent';
 import TransitionState, { TransitionError } from './transition-state';
 import { log, promiseLabel } from './utils';
 
-export { default as TransitionAborted } from './transition-aborted-error';
+export type OnFulfilled<T, TResult1> =
+  | ((value: T) => TResult1 | PromiseLike<TResult1>)
+  | undefined
+  | null;
+export type OnRejected<T, TResult2> =
+  | ((reason: T) => TResult2 | PromiseLike<TResult2>)
+  | undefined
+  | null;
 
 /**
   A Transition is a thennable (a promise-like object) that represents
@@ -377,7 +384,7 @@ export class Transition {
 
   Logs and returns an instance of TransitionAborted.
  */
-export function logAbort(transition: Transition) {
+export function logAbort(transition: Transition): ITransitionAbortedError {
   log(transition.router, transition.sequence, 'detected abort.');
   return new TransitionAborted();
 }

--- a/lib/rsvp/index.d.ts
+++ b/lib/rsvp/index.d.ts
@@ -1,9 +1,14 @@
-declare module "rsvp" {
+declare module 'rsvp' {
   export interface PromiseContructor {
-    new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+    new <T>(
+      executor: (
+        resolve: (value?: T | PromiseLike<T>) => void,
+        reject: (reason?: any) => void
+      ) => void
+    ): Promise<T>;
     resolve<T>(value: T | PromiseLike<T>, label?: string): Promise<T>;
     reject<T = never>(reason?: any, label?: string): Promise<T>;
-    all(values: any[]): Promise<any[]>
+    all(values: any[]): Promise<any[]>;
   }
 
   export const resolve: (value: any | PromiseLike<any>, label?: string) => Promise<any>;
@@ -11,8 +16,14 @@ declare module "rsvp" {
   export const configure: (key: string, value?: any) => void;
   export const Promise: PromiseContructor;
 
-  export type OnFulfilled<T, TResult1> = ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null;
-  export type OnRejected<T, TResult2> = ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null;
+  export type OnFulfilled<T, TResult1> =
+    | ((value: T) => TResult1 | PromiseLike<TResult1>)
+    | undefined
+    | null;
+  export type OnRejected<T, TResult2> =
+    | ((reason: T) => TResult2 | PromiseLike<TResult2>)
+    | undefined
+    | null;
 
   export interface Promise<T> extends PromiseLike<T> {
     then<TResult1 = T, TResult2 = never>(
@@ -27,4 +38,3 @@ declare module "rsvp" {
     finally<U>(onFinally?: U | PromiseLike<U>, label?: string): Promise<T>;
   }
 }
-


### PR DESCRIPTION
Since `Transition` is exported the RSVP types can collide with `@types/rsvp`. This inlines the promise callback types. Also `TransitionAbortedError` types were not correct. These were causing code quality issues in Ember.