### PR TITLE
[Breaking] RouteInfo Type And Transition.(from|to)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 6
+  - 6
 
 sudo: false
 dist: trusty
@@ -14,6 +14,10 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
+
+script:
+  - yarn run problems
+  - yarn run test
 
 install:
   - yarn install --no-lockfile --non-interactive

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -1,4 +1,4 @@
 export { default } from './router';
 export { Transition } from './transition';
 export { default as TransitionState } from './transition-state';
-export { default as HandlerInfo, IHandler } from './handler-info';
+export { Route } from './route-info';

--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -38,10 +38,6 @@ export interface Route extends RouteHooks {
 
 export type Continuation = () => PromiseLike<boolean> | boolean;
 
-export interface IResolvedModel {
-  [key: string]: unknown;
-}
-
 // class RouteInfo {
 //   constructor(
 //     routeName: string,
@@ -52,7 +48,7 @@ export interface IResolvedModel {
 //   ) {}
 // }
 
-export default abstract class PrivateRouteInfo {
+export default class PrivateRouteInfo {
   private _routePromise?: Promise<Route> = undefined;
   private _route?: Route = undefined;
   protected router: Router;

--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -91,7 +91,7 @@ export interface IResolvedModel {
 export default abstract class PrivateRouteInfo {
   private _routePromise?: Promise<Route> = undefined;
   private _route?: Route = undefined;
-  private router: Router;
+  protected router: Router;
   name: string;
   params: Dict<unknown> = {};
   queryParams?: Dict<unknown>;
@@ -317,8 +317,8 @@ export class ResolvedRouteInfo extends PrivateRouteInfo {
 
 export class UnresolvedHandlerInfoByParam extends PrivateRouteInfo {
   params: Dict<unknown> = {};
-  constructor(name: string, router: Router, params: Dict<unknown>, handler?: Route) {
-    super(name, router, handler);
+  constructor(name: string, router: Router, params: Dict<unknown>, route?: Route) {
+    super(name, router, route);
     this.params = params;
   }
 
@@ -358,9 +358,9 @@ export class UnresolvedHandlerInfoByObject extends PrivateRouteInfo {
   constructor(name: string, names: string[], router: Router, context: Dict<unknown>) {
     super(name, router);
     this.names = names;
-    this.serializer = serializer;
     this.context = context;
     this.names = this.names || [];
+    this.serializer = this.router.getSerializer(name);
   }
 
   getModel(transition: Transition) {

--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -27,23 +27,6 @@ export interface RouteHooks {
   contextDidChange?(): void;
   // Underscore methods for some reason
   redirect?(context: Dict<unknown>, transition: Transition): void;
-  _model?(
-    params: Dict<unknown>,
-    transition: Transition
-  ): Promise<Dict<unknown> | null | undefined> | undefined | Dict<unknown>;
-  _deserialize?(params: Dict<unknown>, transition: Transition): Dict<unknown>;
-  _serialize?(model: Dict<unknown>, params: string[]): Dict<unknown>;
-  _beforeModel?(transition: Transition): Promise<Dict<unknown> | null | undefined> | undefined;
-  _afterModel?(
-    resolvedModel: Dict<unknown>,
-    transition: Transition
-  ): Promise<Dict<unknown> | null | undefined>;
-  _setup?(context: Dict<unknown>, transition: Transition): void;
-  _enter?(transition: Transition): void;
-  _exit?(transition?: Transition): void;
-  _reset?(wasReset: boolean, transition?: Transition): void;
-  _contextDidChange?(): void;
-  _redirect?(context: Dict<unknown>, transition: Transition): void;
 }
 
 export interface Route extends RouteHooks {
@@ -193,9 +176,7 @@ export default abstract class PrivateRouteInfo {
 
     let result;
     if (this.route) {
-      if (this.route._beforeModel !== undefined) {
-        result = this.route._beforeModel(transition);
-      } else if (this.route.beforeModel !== undefined) {
+      if (this.route.beforeModel !== undefined) {
         result = this.route.beforeModel(transition);
       }
     }
@@ -219,9 +200,7 @@ export default abstract class PrivateRouteInfo {
 
     let result;
     if (this.route !== undefined) {
-      if (this.route._afterModel !== undefined) {
-        result = this.route._afterModel(resolvedModel!, transition);
-      } else if (this.route.afterModel !== undefined) {
+      if (this.route.afterModel !== undefined) {
         result = this.route.afterModel(resolvedModel!, transition);
       }
     }
@@ -317,12 +296,8 @@ export class UnresolvedRouteInfoByParam extends PrivateRouteInfo {
 
     let result: Dict<unknown> | undefined = undefined;
 
-    if (route._deserialize) {
-      result = route._deserialize(fullParams, transition);
-    } else if (route.deserialize) {
+    if (route.deserialize) {
       result = route.deserialize(fullParams, transition);
-    } else if (route._model) {
-      result = route._model(fullParams, transition);
     } else if (route.model) {
       result = route.model(fullParams, transition);
     }
@@ -380,10 +355,6 @@ export class UnresolvedRouteInfoByObject extends PrivateRouteInfo {
       // invoke this.serializer unbound (getSerializer returns a stateless function)
       return this.serializer.call(null, model, names);
     } else if (this.route !== undefined) {
-      if (this.route._serialize) {
-        return this.route._serialize(model, names);
-      }
-
       if (this.route.serialize) {
         return this.route.serialize(model, names);
       }

--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -54,7 +54,7 @@ let ROUTE_INFO_LINKS = new WeakMap<PrivateRouteInfo, IRouteInfo>();
 
 export function toReadOnlyRouteInfo(routeInfos: PrivateRouteInfo[]) {
   return routeInfos.map((info, i) => {
-    let { name, params, queryParams } = info;
+    let { name, params, queryParams, paramNames } = info;
     let publicRouteInfo = new class RouteInfo implements IRouteInfo {
       find(predicate: (this: void, routeInfo: IRouteInfo, i: number) => boolean, thisArg: any) {
         let routeInfo;
@@ -72,6 +72,10 @@ export function toReadOnlyRouteInfo(routeInfos: PrivateRouteInfo[]) {
 
       get name() {
         return name;
+      }
+
+      get paramNames() {
+        return paramNames;
       }
 
       get parent() {

--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -161,9 +161,7 @@ export default abstract class Router {
       forEach<HandlerInfo>(this.state.handlerInfos.slice().reverse(), function(handlerInfo) {
         let handler = handlerInfo.route;
         if (handler !== undefined) {
-          if (handler._exit !== undefined) {
-            handler._exit();
-          } else if (handler.exit !== undefined) {
+          if (handler.exit !== undefined) {
             handler.exit();
           }
         }
@@ -509,15 +507,11 @@ function setupContexts(router: Router, newState: TransitionState, transition?: T
     delete handler!.context;
 
     if (handler !== undefined) {
-      if (handler._reset !== undefined) {
-        handler._reset(true, transition);
-      } else if (handler.reset !== undefined) {
+      if (handler.reset !== undefined) {
         handler.reset(true, transition);
       }
 
-      if (handler._exit !== undefined) {
-        handler._exit(transition);
-      } else if (handler.exit !== undefined) {
+      if (handler.exit !== undefined) {
         handler.exit(transition);
       }
     }
@@ -531,9 +525,7 @@ function setupContexts(router: Router, newState: TransitionState, transition?: T
     for (i = 0, l = partition.reset.length; i < l; i++) {
       handler = partition.reset[i].route;
       if (handler !== undefined) {
-        if (handler._reset !== undefined) {
-          handler._reset(false, transition);
-        } else if (handler.reset !== undefined) {
+        if (handler.reset !== undefined) {
           handler.reset(false, transition);
         }
       }
@@ -577,9 +569,7 @@ function handlerEnteredOrUpdated(
 
   function _handlerEnteredOrUpdated(handler: Route) {
     if (enter) {
-      if (handler._enter !== undefined) {
-        handler._enter(transition);
-      } else if (handler.enter !== undefined) {
+      if (handler.enter !== undefined) {
         handler.enter(transition);
       }
     }
@@ -590,15 +580,11 @@ function handlerEnteredOrUpdated(
 
     handler.context = context;
 
-    if (handler._contextDidChange !== undefined) {
-      handler._contextDidChange();
-    } else if (handler.contextDidChange !== undefined) {
+    if (handler.contextDidChange !== undefined) {
       handler.contextDidChange();
     }
 
-    if (handler._setup !== undefined) {
-      handler._setup(context!, transition);
-    } else if (handler.setup !== undefined) {
+    if (handler.setup !== undefined) {
       handler.setup(context!, transition);
     }
 

--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -33,6 +33,11 @@ export interface DidTransitionFunc {
   (handlerInfos: HandlerInfo[]): void;
 }
 
+export interface ParsedHandler {
+  handler: string;
+  names: string[];
+}
+
 export default abstract class Router {
   log?: (message: string) => void;
   state?: TransitionState = undefined;
@@ -310,7 +315,7 @@ export default abstract class Router {
     }
 
     let targetHandler = targetHandlerInfos[targetHandlerInfos.length - 1].name;
-    let recogHandlers = this.recognizer.handlersFor(targetHandler) as Route[];
+    let recogHandlers: ParsedHandler[] = this.recognizer.handlersFor(targetHandler);
 
     let index = 0;
     for (len = recogHandlers.length; index < len; ++index) {

--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -272,7 +272,7 @@ export default abstract class Router {
 
     // Construct a TransitionIntent with the provided params
     // and apply it to the present state of the router.
-    let intent = new NamedTransitionIntent(handlerName, this, suppliedParams);
+    let intent = new NamedTransitionIntent(handlerName, this, undefined, suppliedParams);
     let state = intent.applyToState(this.state!, false);
 
     let params: Params = {};

--- a/lib/router/transition-intent.ts
+++ b/lib/router/transition-intent.ts
@@ -1,19 +1,14 @@
-import RouteRecognizer from 'route-recognizer';
 import { Dict } from './core';
-import { GetHandlerFunc, GetSerializerFunc } from './router';
+import Router from './router';
 import TransitionState from './transition-state';
 
 export abstract class TransitionIntent {
   data: Dict<unknown>;
-  constructor(data?: Dict<unknown>) {
+  router: Router;
+  constructor(router: Router, data?: Dict<unknown>) {
+    this.router = router;
     this.data = data || {};
   }
   preTransitionState?: TransitionState;
-  abstract applyToState(
-    oldState: TransitionState,
-    recognizer: RouteRecognizer,
-    getHandler: GetHandlerFunc,
-    isIntermidate: boolean,
-    getSerializer: GetSerializerFunc
-  ): TransitionState;
+  abstract applyToState(oldState: TransitionState, isIntermidate: boolean): TransitionState;
 }

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -68,7 +68,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
       let result = parsedHandlers[i];
       let name = result.handler;
 
-      let oldHandlerInfo = oldState.handlerInfos[i];
+      let oldHandlerInfo = oldState.routeInfos[i];
       let newHandlerInfo = null;
 
       if (result.names.length > 0) {
@@ -121,7 +121,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
         handlerToUse = handlerToUse.becomeResolved(null, handlerToUse.context!);
       }
 
-      newState.handlerInfos.unshift(handlerToUse);
+      newState.routeInfos.unshift(handlerToUse);
     }
 
     if (objects.length > 0) {
@@ -132,7 +132,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
     }
 
     if (!isIntermediate) {
-      this.invalidateChildren(newState.handlerInfos, invalidateIndex);
+      this.invalidateChildren(newState.routeInfos, invalidateIndex);
     }
 
     merge(newState.queryParams, this.queryParams || {});
@@ -172,7 +172,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
       return oldHandlerInfo;
     } else {
       if (this.preTransitionState) {
-        let preTransitionHandlerInfo = this.preTransitionState.handlerInfos[i];
+        let preTransitionHandlerInfo = this.preTransitionState.routeInfos[i];
         objectToUse = preTransitionHandlerInfo && preTransitionHandlerInfo.context!;
       } else {
         // Ideally we should throw this error to provide maximal

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -4,7 +4,7 @@ import HandlerInfo, {
   UnresolvedHandlerInfoByObject,
   UnresolvedHandlerInfoByParam,
 } from '../route-info';
-import Router, { SerializerFunc } from '../router';
+import Router from '../router';
 import { TransitionIntent } from '../transition-intent';
 import TransitionState from '../transition-state';
 import { extractQueryParams, isParam, merge } from '../utils';

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -1,5 +1,5 @@
 import { Dict } from '../core';
-import HandlerInfo, {
+import InternalRouteInfo, {
   Route,
   UnresolvedRouteInfoByObject,
   UnresolvedRouteInfoByParam,
@@ -140,12 +140,18 @@ export default class NamedTransitionIntent extends TransitionIntent {
     return newState;
   }
 
-  invalidateChildren(handlerInfos: HandlerInfo[], invalidateIndex: number) {
+  invalidateChildren(handlerInfos: InternalRouteInfo[], invalidateIndex: number) {
     for (let i = invalidateIndex, l = handlerInfos.length; i < l; ++i) {
       let handlerInfo = handlerInfos[i];
       if (handlerInfo.isResolved) {
-        let { name, params, route } = handlerInfos[i];
-        handlerInfos[i] = new UnresolvedRouteInfoByParam(name, this.router, params, route);
+        let { name, params, route, paramNames } = handlerInfos[i];
+        handlerInfos[i] = new UnresolvedRouteInfoByParam(
+          this.router,
+          name,
+          paramNames,
+          params,
+          route
+        );
       }
     }
   }
@@ -154,7 +160,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
     name: string,
     names: string[],
     objects: Dict<unknown>[],
-    oldHandlerInfo: HandlerInfo,
+    oldHandlerInfo: InternalRouteInfo,
     _targetRouteName: string,
     i: number
   ) {
@@ -186,14 +192,14 @@ export default class NamedTransitionIntent extends TransitionIntent {
       }
     }
 
-    return new UnresolvedRouteInfoByObject(name, names, this.router, objectToUse);
+    return new UnresolvedRouteInfoByObject(this.router, name, names, objectToUse);
   }
 
   createParamHandlerInfo(
     name: string,
     names: string[],
     objects: Dict<unknown>[],
-    oldHandlerInfo: HandlerInfo
+    oldHandlerInfo: InternalRouteInfo
   ) {
     let params: Dict<unknown> = {};
 
@@ -223,6 +229,6 @@ export default class NamedTransitionIntent extends TransitionIntent {
       }
     }
 
-    return new UnresolvedRouteInfoByParam(name, this.router, params);
+    return new UnresolvedRouteInfoByParam(this.router, name, names, params);
   }
 }

--- a/lib/router/transition-intent/url-transition-intent.ts
+++ b/lib/router/transition-intent/url-transition-intent.ts
@@ -55,12 +55,12 @@ export default class URLTransitionIntent extends TransitionIntent {
         newHandlerInfo.routePromise = newHandlerInfo.routePromise.then(checkHandlerAccessibility);
       }
 
-      let oldHandlerInfo = oldState.handlerInfos[i];
+      let oldHandlerInfo = oldState.routeInfos[i];
       if (statesDiffer || newHandlerInfo.shouldSupercede(oldHandlerInfo)) {
         statesDiffer = true;
-        newState.handlerInfos[i] = newHandlerInfo;
+        newState.routeInfos[i] = newHandlerInfo;
       } else {
-        newState.handlerInfos[i] = oldHandlerInfo;
+        newState.routeInfos[i] = oldHandlerInfo;
       }
     }
 

--- a/lib/router/transition-intent/url-transition-intent.ts
+++ b/lib/router/transition-intent/url-transition-intent.ts
@@ -1,4 +1,4 @@
-import { Route, UnresolvedHandlerInfoByParam } from '../route-info';
+import { Route, UnresolvedRouteInfoByParam } from '../route-info';
 import Router from '../router';
 import { TransitionIntent } from '../transition-intent';
 import TransitionState from '../transition-state';
@@ -43,7 +43,7 @@ export default class URLTransitionIntent extends TransitionIntent {
       let result = results[i]!;
       let name = result.handler as string;
 
-      let newHandlerInfo = new UnresolvedHandlerInfoByParam(name, this.router, result.params);
+      let newHandlerInfo = new UnresolvedRouteInfoByParam(name, this.router, result.params);
 
       let handler = newHandlerInfo.route;
 

--- a/lib/router/transition-intent/url-transition-intent.ts
+++ b/lib/router/transition-intent/url-transition-intent.ts
@@ -43,7 +43,7 @@ export default class URLTransitionIntent extends TransitionIntent {
       let result = results[i]!;
       let name = result.handler as string;
 
-      let newHandlerInfo = new UnresolvedRouteInfoByParam(name, this.router, result.params);
+      let newHandlerInfo = new UnresolvedRouteInfoByParam(this.router, name, [], result.params);
 
       let handler = newHandlerInfo.route;
 

--- a/lib/router/transition-state.ts
+++ b/lib/router/transition-state.ts
@@ -1,6 +1,6 @@
 import { Promise } from 'rsvp';
 import { Dict } from './core';
-import RouteInfo, { Continuation, Route } from './route-info';
+import InternalRouteInfo, { Continuation, Route } from './route-info';
 import { Transition } from './transition';
 import { forEach, promiseLabel } from './utils';
 
@@ -9,7 +9,7 @@ interface IParams {
 }
 
 export default class TransitionState {
-  routeInfos: RouteInfo[] = [];
+  routeInfos: InternalRouteInfo[] = [];
   queryParams: Dict<unknown> = {};
   params: IParams = {};
 
@@ -75,7 +75,7 @@ export default class TransitionState {
       );
     }
 
-    function proceed(resolvedRouteInfo: RouteInfo): Promise<RouteInfo> {
+    function proceed(resolvedRouteInfo: InternalRouteInfo): Promise<InternalRouteInfo> {
       let wasAlreadyResolved = currentState.routeInfos[transition.resolveIndex].isResolved;
 
       // Swap the previously unresolved routeInfo with

--- a/lib/router/transition-state.ts
+++ b/lib/router/transition-state.ts
@@ -1,6 +1,6 @@
 import { Promise } from 'rsvp';
 import { Dict } from './core';
-import HandlerInfo, { Continuation, IHandler } from './handler-info';
+import HandlerInfo, { Continuation, Route } from './route-info';
 import { Transition } from './transition';
 import { forEach, promiseLabel } from './utils';
 
@@ -68,7 +68,7 @@ export default class TransitionState {
       return Promise.reject(
         new TransitionError(
           error,
-          currentState.handlerInfos[errorHandlerIndex].handler!,
+          currentState.handlerInfos[errorHandlerIndex].route!,
           wasAborted,
           currentState
         )
@@ -87,7 +87,7 @@ export default class TransitionState {
         // vs. afterModel is so that redirects into child
         // routes don't re-run the model hooks for this
         // already-resolved route.
-        let handler = resolvedHandlerInfo.handler;
+        let handler = resolvedHandlerInfo.route;
         if (handler !== undefined) {
           if (handler._redirect) {
             handler._redirect(resolvedHandlerInfo.context!, transition);
@@ -125,7 +125,7 @@ export default class TransitionState {
 export class TransitionError {
   constructor(
     public error: Error,
-    public handler: IHandler,
+    public handler: Route,
     public wasAborted: boolean,
     public state: TransitionState
   ) {}

--- a/lib/router/transition-state.ts
+++ b/lib/router/transition-state.ts
@@ -89,9 +89,7 @@ export default class TransitionState {
         // already-resolved route.
         let handler = resolvedHandlerInfo.route;
         if (handler !== undefined) {
-          if (handler._redirect) {
-            handler._redirect(resolvedHandlerInfo.context!, transition);
-          } else if (handler.redirect) {
+          if (handler.redirect) {
             handler.redirect(resolvedHandlerInfo.context!, transition);
           }
         }

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -101,15 +101,15 @@ export class Transition {
     if (state) {
       this.params = state.params;
       this.queryParams = state.queryParams;
-      this.handlerInfos = state.handlerInfos;
+      this.handlerInfos = state.routeInfos;
 
-      let len = state.handlerInfos.length;
+      let len = state.routeInfos.length;
       if (len) {
-        this.targetName = state.handlerInfos[len - 1].name;
+        this.targetName = state.routeInfos[len - 1].name;
       }
 
       for (let i = 0; i < len; ++i) {
-        let handlerInfo = state.handlerInfos[i];
+        let handlerInfo = state.routeInfos[i];
 
         // TODO: this all seems hacky
         if (!handlerInfo.isResolved) {
@@ -131,7 +131,7 @@ export class Transition {
           if (result.wasAborted || this.isAborted) {
             return Promise.reject(logAbort(this));
           } else {
-            this.trigger(false, 'error', result.error, this, result.handler);
+            this.trigger(false, 'error', result.error, this, result.route);
             this.abort();
             return Promise.reject(result.error);
           }
@@ -338,7 +338,7 @@ export class Transition {
    */
   trigger(ignoreFailure: boolean, name: string, ...args: any[]) {
     this.router.triggerEvent(
-      this.state!.handlerInfos.slice(0, this.resolveIndex + 1),
+      this.state!.routeInfos.slice(0, this.resolveIndex + 1),
       ignoreFailure,
       name,
       args

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -1,6 +1,6 @@
 import { Promise } from 'rsvp';
 import { Dict, Maybe } from './core';
-import HandlerInfo, { Route } from './route-info';
+import HandlerInfo, { IRouteInfo, Route } from './route-info';
 import Router from './router';
 import TransitionAborted, { ITransitionAbortedError } from './transition-aborted-error';
 import { TransitionIntent } from './transition-intent';
@@ -33,6 +33,8 @@ export type OnRejected<T, TResult2> =
  */
 export class Transition {
   state?: TransitionState;
+  from: Maybe<IRouteInfo> = null;
+  to: Maybe<IRouteInfo> = null;
   router: Router;
   data: Dict<unknown>;
   intent?: TransitionIntent;

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -1,6 +1,6 @@
 import { Promise } from 'rsvp';
 import { Dict, Maybe } from './core';
-import HandlerInfo, { IHandler } from './handler-info';
+import HandlerInfo, { Route } from './route-info';
 import Router from './router';
 import TransitionAborted, { ITransitionAbortedError } from './transition-aborted-error';
 import { TransitionIntent } from './transition-intent';
@@ -43,7 +43,7 @@ export class Transition {
   params: Dict<unknown>;
   handlerInfos: HandlerInfo[];
   targetName: Maybe<string>;
-  pivotHandler: Maybe<IHandler>;
+  pivotHandler: Maybe<Route>;
   sequence: number;
   isAborted = false;
   isActive = true;
@@ -115,7 +115,7 @@ export class Transition {
         if (!handlerInfo.isResolved) {
           break;
         }
-        this.pivotHandler = handlerInfo.handler;
+        this.pivotHandler = handlerInfo.route;
       }
 
       this.sequence = router.currentSequence++;
@@ -143,11 +143,11 @@ export class Transition {
   }
 
   // Todo Delete?
-  isExiting(handler: IHandler | string) {
+  isExiting(handler: Route | string) {
     let handlerInfos = this.handlerInfos;
     for (let i = 0, len = handlerInfos.length; i < len; ++i) {
       let handlerInfo = handlerInfos[i];
-      if (handlerInfo.name === handler || handlerInfo.handler === handler) {
+      if (handlerInfo.name === handler || handlerInfo.route === handler) {
         return false;
       }
     }
@@ -318,7 +318,7 @@ export class Transition {
     _name: string,
     err?: Error,
     transition?: Transition,
-    handler?: IHandler
+    handler?: Route
   ) {
     this.trigger(ignoreFailure, _name, err, transition, handler);
   }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
   "name": "router_js",
   "version": "4.0.3",
-  "description": "A lightweight JavaScript library is built on top of route-recognizer and rsvp.js to provide an API for handling routes",
-  "keywords": [
-    "route-recognizer",
-    "router",
-    "rsvp"
-  ],
+  "description":
+    "A lightweight JavaScript library is built on top of route-recognizer and rsvp.js to provide an API for handling routes",
+  "keywords": ["route-recognizer", "router", "rsvp"],
   "bugs": {
     "url": "https://github.com/tildeio/router.js/issues"
   },
@@ -20,13 +17,11 @@
   },
   "scripts": {
     "prepublish": "ember build",
+    "problems": "tsc -p tsconfig.json --noEmit",
     "start": "ember server",
     "test": "ember test"
   },
-  "files": [
-    "dist/cjs",
-    "dist/modules"
-  ],
+  "files": ["dist/cjs", "dist/modules"],
   "dependencies": {
     "@types/node": "^10.5.5"
   },

--- a/tests/async_get_handler_test.ts
+++ b/tests/async_get_handler_test.ts
@@ -1,4 +1,4 @@
-import Router, { IHandler } from 'router';
+import Router, { Route } from 'router';
 import { Dict } from 'router/core';
 import { Promise } from 'rsvp';
 import { createHandler } from './test_helpers';
@@ -6,7 +6,7 @@ import { createHandler } from './test_helpers';
 // Intentionally use QUnit.module instead of module from test_helpers
 // so that we avoid using Backburner to handle the async portions of
 // the test suite
-let handlers: Dict<IHandler>;
+let handlers: Dict<Route>;
 let router: Router;
 QUnit.module('Async Get Handler', {
   beforeEach: function() {
@@ -19,7 +19,7 @@ QUnit.module('Async Get Handler', {
       willTransition() {}
       replaceURL() {}
       triggerEvent() {}
-      getHandler(_name: string): never {
+      getRoute(_name: string): never {
         throw new Error('never');
       }
 
@@ -47,7 +47,7 @@ QUnit.module('Async Get Handler', {
 QUnit.test('can transition to lazily-resolved routes', function(assert) {
   let done = assert.async();
 
-  router.getHandler = function(name: string) {
+  router.getRoute = function(name: string) {
     return new Promise(function(resolve) {
       setTimeout(function() {
         resolve(handlers[name] || (handlers[name] = createHandler('empty')));
@@ -83,7 +83,7 @@ QUnit.test('calls hooks of lazily-resolved routes in order', function(assert) {
   let done = assert.async();
   let operations: string[] = [];
 
-  router.getHandler = function(name: string) {
+  router.getRoute = function(name: string) {
     operations.push('get handler ' + name);
     return new Promise(function(resolve) {
       let timeoutLength = name === 'foo' ? 100 : 1;

--- a/tests/handler_info_test.ts
+++ b/tests/handler_info_test.ts
@@ -16,7 +16,7 @@ module('HandlerInfo');
 
 test('ResolvedHandlerInfos resolve to themselves', function(assert) {
   let router = new StubRouter();
-  let handlerInfo = new ResolvedRouteInfo('foo', router, createHandler('empty'), {});
+  let handlerInfo = new ResolvedRouteInfo(router, 'foo', [], {}, createHandler('empty'));
   handlerInfo.resolve().then(function(resolvedHandlerInfo) {
     assert.equal(handlerInfo, resolvedHandlerInfo);
   });
@@ -24,10 +24,10 @@ test('ResolvedHandlerInfos resolve to themselves', function(assert) {
 
 test('UnresolvedHandlerInfoByParam defaults params to {}', function(assert) {
   let router = new StubRouter();
-  let handlerInfo = new UnresolvedRouteInfoByParam('empty', router, {});
+  let handlerInfo = new UnresolvedRouteInfoByParam(router, 'empty', [], {});
   assert.deepEqual(handlerInfo.params, {});
 
-  let handlerInfo2 = new UnresolvedRouteInfoByParam('empty', router, { foo: 5 });
+  let handlerInfo2 = new UnresolvedRouteInfoByParam(router, 'empty', [], { foo: 5 });
   assert.deepEqual(handlerInfo2.params, { foo: 5 });
 });
 
@@ -124,8 +124,9 @@ test('UnresolvedHandlerInfoByParam gets its model hook called', function(assert)
   let transition = {};
 
   let handlerInfo = new UnresolvedRouteInfoByParam(
-    'empty',
     router,
+    'empty',
+    [],
     { first_name: 'Alex', last_name: 'Matchnerd' },
     createHandler('h', {
       model: function(params: Dict<unknown>, payload: Dict<unknown>) {
@@ -152,9 +153,9 @@ test('UnresolvedHandlerInfoByObject does NOT get its model hook called', functio
     });
   }
   let handlerInfo = new Handler(
+    new StubRouter(),
     'unresolved',
     ['wat'],
-    new StubRouter(),
     resolve({ name: 'dorkletons' })
   );
 

--- a/tests/handler_info_test.ts
+++ b/tests/handler_info_test.ts
@@ -2,10 +2,10 @@ import { Transition } from 'router';
 import { Dict } from 'router/core';
 import HandlerInfo, {
   noopGetHandler,
-  ResolvedHandlerInfo,
+  ResolvedRouteInfo,
   UnresolvedHandlerInfoByObject,
   UnresolvedHandlerInfoByParam,
-} from 'router/handler-info';
+} from 'router/route-info';
 import { reject, resolve } from 'rsvp';
 import { createHandler, createHandlerInfo, module, test } from './test_helpers';
 
@@ -16,7 +16,7 @@ function noop() {
 module('HandlerInfo');
 
 test('ResolvedHandlerInfos resolve to themselves', function(assert) {
-  let handlerInfo = new ResolvedHandlerInfo('foo', createHandler('empty'), {});
+  let handlerInfo = new ResolvedRouteInfo('foo', createHandler('empty'), {});
   handlerInfo.resolve().then(function(resolvedHandlerInfo) {
     assert.equal(handlerInfo, resolvedHandlerInfo);
   });
@@ -52,7 +52,7 @@ test('HandlerInfo#resolve resolves with a ResolvedHandlerInfo', function(assert)
   handlerInfo
     .resolve(() => false, {} as Transition)
     .then(function(resolvedHandlerInfo: HandlerInfo) {
-      assert.ok(resolvedHandlerInfo instanceof ResolvedHandlerInfo);
+      assert.ok(resolvedHandlerInfo instanceof ResolvedRouteInfo);
     });
 });
 
@@ -143,7 +143,7 @@ test('UnresolvedHandlerInfoByObject does NOT get its model hook called', functio
   assert.expect(1);
 
   class Handler extends UnresolvedHandlerInfoByObject {
-    handler = createHandler('uresolved', {
+    route = createHandler('uresolved', {
       model: function() {
         assert.ok(false, "I shouldn't be called because I already have a context/model");
       },

--- a/tests/handler_info_test.ts
+++ b/tests/handler_info_test.ts
@@ -1,13 +1,12 @@
 import { Transition } from 'router';
 import { Dict } from 'router/core';
 import HandlerInfo, {
-  noopGetHandler,
   ResolvedRouteInfo,
   UnresolvedHandlerInfoByObject,
   UnresolvedHandlerInfoByParam,
 } from 'router/route-info';
 import { reject, resolve } from 'rsvp';
-import { createHandler, createHandlerInfo, module, test } from './test_helpers';
+import { createHandler, createHandlerInfo, module, StubRouter, test } from './test_helpers';
 
 function noop() {
   return resolve(true);
@@ -16,17 +15,19 @@ function noop() {
 module('HandlerInfo');
 
 test('ResolvedHandlerInfos resolve to themselves', function(assert) {
-  let handlerInfo = new ResolvedRouteInfo('foo', createHandler('empty'), {});
+  let router = new StubRouter();
+  let handlerInfo = new ResolvedRouteInfo('foo', router, createHandler('empty'), {});
   handlerInfo.resolve().then(function(resolvedHandlerInfo) {
     assert.equal(handlerInfo, resolvedHandlerInfo);
   });
 });
 
 test('UnresolvedHandlerInfoByParam defaults params to {}', function(assert) {
-  let handlerInfo = new UnresolvedHandlerInfoByParam('empty', noopGetHandler, {});
+  let router = new StubRouter();
+  let handlerInfo = new UnresolvedHandlerInfoByParam('empty', router, {});
   assert.deepEqual(handlerInfo.params, {});
 
-  let handlerInfo2 = new UnresolvedHandlerInfoByParam('empty', noopGetHandler, { foo: 5 });
+  let handlerInfo2 = new UnresolvedHandlerInfoByParam('empty', router, { foo: 5 });
   assert.deepEqual(handlerInfo2.params, { foo: 5 });
 });
 
@@ -118,12 +119,13 @@ test('HandlerInfo#resolve runs afterModel hook on handler', function(assert) {
 
 test('UnresolvedHandlerInfoByParam gets its model hook called', function(assert) {
   assert.expect(2);
+  let router = new StubRouter();
 
   let transition = {};
 
   let handlerInfo = new UnresolvedHandlerInfoByParam(
     'empty',
-    noopGetHandler,
+    router,
     { first_name: 'Alex', last_name: 'Matchnerd' },
     createHandler('h', {
       model: function(params: Dict<unknown>, payload: Dict<unknown>) {
@@ -152,8 +154,7 @@ test('UnresolvedHandlerInfoByObject does NOT get its model hook called', functio
   let handlerInfo = new Handler(
     'unresolved',
     ['wat'],
-    noopGetHandler,
-    () => {},
+    new StubRouter(),
     resolve({ name: 'dorkletons' })
   );
 

--- a/tests/handler_info_test.ts
+++ b/tests/handler_info_test.ts
@@ -2,8 +2,8 @@ import { Transition } from 'router';
 import { Dict } from 'router/core';
 import HandlerInfo, {
   ResolvedRouteInfo,
-  UnresolvedHandlerInfoByObject,
-  UnresolvedHandlerInfoByParam,
+  UnresolvedRouteInfoByObject,
+  UnresolvedRouteInfoByParam,
 } from 'router/route-info';
 import { reject, resolve } from 'rsvp';
 import { createHandler, createHandlerInfo, module, StubRouter, test } from './test_helpers';
@@ -24,10 +24,10 @@ test('ResolvedHandlerInfos resolve to themselves', function(assert) {
 
 test('UnresolvedHandlerInfoByParam defaults params to {}', function(assert) {
   let router = new StubRouter();
-  let handlerInfo = new UnresolvedHandlerInfoByParam('empty', router, {});
+  let handlerInfo = new UnresolvedRouteInfoByParam('empty', router, {});
   assert.deepEqual(handlerInfo.params, {});
 
-  let handlerInfo2 = new UnresolvedHandlerInfoByParam('empty', router, { foo: 5 });
+  let handlerInfo2 = new UnresolvedRouteInfoByParam('empty', router, { foo: 5 });
   assert.deepEqual(handlerInfo2.params, { foo: 5 });
 });
 
@@ -123,7 +123,7 @@ test('UnresolvedHandlerInfoByParam gets its model hook called', function(assert)
 
   let transition = {};
 
-  let handlerInfo = new UnresolvedHandlerInfoByParam(
+  let handlerInfo = new UnresolvedRouteInfoByParam(
     'empty',
     router,
     { first_name: 'Alex', last_name: 'Matchnerd' },
@@ -144,7 +144,7 @@ test('UnresolvedHandlerInfoByParam gets its model hook called', function(assert)
 test('UnresolvedHandlerInfoByObject does NOT get its model hook called', function(assert) {
   assert.expect(1);
 
-  class Handler extends UnresolvedHandlerInfoByObject {
+  class Handler extends UnresolvedRouteInfoByObject {
     route = createHandler('uresolved', {
       model: function() {
         assert.ok(false, "I shouldn't be called because I already have a context/model");

--- a/tests/query_params_test.ts
+++ b/tests/query_params_test.ts
@@ -1,7 +1,7 @@
 import { MatchCallback } from 'route-recognizer';
-import Router, { IHandler, Transition } from 'router';
+import Router, { Route, Transition } from 'router';
 import { Dict, Maybe } from 'router/core';
-import HandlerInfo from 'router/handler-info';
+import HandlerInfo from 'router/route-info';
 import { Promise } from 'rsvp';
 import {
   createHandler,
@@ -12,7 +12,7 @@ import {
   trigger,
 } from './test_helpers';
 
-let router: Router, handlers: Dict<IHandler>, expectedUrl: Maybe<string>;
+let router: Router, handlers: Dict<Route>, expectedUrl: Maybe<string>;
 let scenarios = [
   {
     name: 'Sync Get Handler',
@@ -54,7 +54,7 @@ scenarios.forEach(function(scenario) {
       replaceURL(name: string) {
         this.updateURL(name);
       }
-      getHandler(name: string) {
+      getRoute(name: string) {
         return scenario.getHandler(name);
       }
       getSerializer(): never {
@@ -297,7 +297,7 @@ scenarios.forEach(function(scenario) {
           if (count === 0) {
             assert.ok(false, "shouldn't fire on first trans");
           } else {
-            router.refresh(this as IHandler);
+            router.refresh(this as Route);
           }
         },
         finalizeQueryParamChange: consumeAllFinalQueryParams,
@@ -452,7 +452,7 @@ scenarios.forEach(function(scenario) {
       },
       events: {
         queryParamsDidChange: function() {
-          router.refresh(this as IHandler);
+          router.refresh(this as Route);
         },
       },
     });
@@ -490,7 +490,7 @@ scenarios.forEach(function(scenario) {
         queryParamsDidChange: function() {
           assert.ok(true, 'index#queryParamsDidChange');
           redirect = causeRedirect;
-          router.refresh(this as IHandler);
+          router.refresh(this as Route);
         },
         finalizeQueryParamChange: function(params: Dict<unknown>, finalParams: Dict<unknown>[]) {
           (finalParams as any).foo = params.foo; // TODO wat

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -354,7 +354,7 @@ scenarios.forEach(function(scenario) {
   });
 
   test('handleURL: Handling a nested URL triggers each handler', function(assert) {
-    assert.expect(35);
+    assert.expect(37);
 
     let posts: Dict<unknown>[] = [];
     let allPosts = { all: true };
@@ -509,8 +509,16 @@ scenarios.forEach(function(scenario) {
           );
           return amazingPosts;
         } else if (counter === 5) {
-          assert.equal(transition.from && transition.from.localName, 'came from same route');
-          assert.equal(transition.to && transition.to.localName, 'going to same route');
+          assert.equal(
+            transition.from && transition.from.localName,
+            'showFilteredPosts',
+            'came from same route'
+          );
+          assert.equal(
+            transition.to && transition.to.localName,
+            'showFilteredPosts',
+            'going to same route'
+          );
           assert.equal(
             transition.from && transition.from.params.filter_id,
             'amazing',

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -3298,25 +3298,6 @@ test("exceptions thrown from model hooks aren't swallowed", function(assert) {
     flushBackburner();
   });
 
-  test('underscore-prefixed hooks are preferred over non-prefixed', function(assert) {
-    assert.expect(2);
-
-    handlers = {
-      showPost: createHandler('showPost', {
-        _model: function() {
-          assert.ok(true);
-          return {};
-        },
-
-        _setup: function() {
-          assert.ok(true);
-        },
-      }),
-    };
-
-    router.handleURL('/posts/1');
-  });
-
   test('A successful transition calls the finally callback', function(assert) {
     assert.expect(1);
 

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -730,7 +730,7 @@ scenarios.forEach(function(scenario) {
   test('applyIntent returns a tentative state based on a named transition', function(assert) {
     transitionTo(router, '/posts');
     let state = router.applyIntent('faq', []);
-    assert.ok(state.handlerInfos.length);
+    assert.ok(state.routeInfos.length);
   });
 
   test('Moving to a new top-level route triggers exit callbacks', function(assert) {
@@ -787,7 +787,7 @@ scenarios.forEach(function(scenario) {
         return router.transitionTo('showPost', postsStore[1]);
       }, shouldNotHappen(assert))
       .then(function() {
-        assert.equal(routePath(router.currentHandlerInfos!), currentPath);
+        assert.equal(routePath(router.currentRouteInfos!), currentPath);
       }, shouldNotHappen(assert));
   });
 
@@ -1675,7 +1675,7 @@ scenarios.forEach(function(scenario) {
 
     assert.ok(postIndexExited, 'Post index handler did not exit');
     assert.ok(showAllPostsExited, 'Show all posts handler did not exit');
-    assert.equal(router.currentHandlerInfos, null, 'currentHandlerInfos should be null');
+    assert.equal(router.currentRouteInfos, null, 'currentHandlerInfos should be null');
   });
 
   test('any of the model hooks can redirect with or without promise', function(assert) {
@@ -2848,7 +2848,7 @@ scenarios.forEach(function(scenario) {
     });
 
     function assertOnRoute(name: string) {
-      let last = router.currentHandlerInfos![router.currentHandlerInfos!.length - 1];
+      let last = router.currentRouteInfos![router.currentRouteInfos!.length - 1];
       assert.equal(last.name, name);
     }
 

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -121,27 +121,57 @@ export function createHandler(name: string, options?: Dict<unknown>): Route {
   );
 }
 
+export class StubRouter extends Router {
+  getRoute(_name: string) {
+    return {} as Route;
+  }
+  getSerializer(_name: string) {
+    return () => {};
+  }
+  updateURL(_url: string): void {
+    throw new Error('Method not implemented.');
+  }
+  replaceURL(_url: string): void {
+    throw new Error('Method not implemented.');
+  }
+  willTransition(
+    _oldHandlerInfos: HandlerInfo[],
+    _newHandlerInfos: HandlerInfo[],
+    _transition: Transition
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+  didTransition(_handlerInfos: HandlerInfo[]): void {
+    throw new Error('Method not implemented.');
+  }
+  triggerEvent(
+    _handlerInfos: HandlerInfo[],
+    _ignoreFailure: boolean,
+    _name: string,
+    _args: unknown[]
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+}
+
 export function createHandlerInfo(name: string, options: Dict<unknown> = {}): HandlerInfo {
   class Stub extends HandlerInfo {
-    constructor(name: string, handler?: Route) {
-      super(name, handler);
+    constructor(name: string, router: Router, handler?: Route) {
+      super(name, router, handler);
     }
     getModel(_transition: Transition) {
       return {};
     }
     getUnresolved() {
-      return new UnresolvedHandlerInfoByParam('empty', noopGetHandler, {});
+      return new UnresolvedHandlerInfoByParam('empty', this.router, {});
     }
-    getRoute = (name: string) => {
-      return createHandler(name);
-    };
   }
 
   let handler = (options.handler as Route) || createHandler('foo');
   delete options.handler;
 
   Object.assign(Stub.prototype, options);
-  let stub = new Stub(name, handler);
+  let stub = new Stub(name, new StubRouter(), handler);
   return stub;
 }
 

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -157,13 +157,13 @@ export class StubRouter extends Router {
 export function createHandlerInfo(name: string, options: Dict<unknown> = {}): HandlerInfo {
   class Stub extends HandlerInfo {
     constructor(name: string, router: Router, handler?: Route) {
-      super(name, router, handler);
+      super(router, name, [], handler);
     }
     getModel(_transition: Transition) {
       return {} as any;
     }
     getUnresolved() {
-      return new UnresolvedRouteInfoByParam('empty', this.router, {});
+      return new UnresolvedRouteInfoByParam(this.router, 'empty', [], {});
     }
   }
 

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -1,7 +1,7 @@
 import Backburner from 'backburner';
 import Router, { Route, Transition } from 'router';
 import { Dict } from 'router/core';
-import HandlerInfo, { noopGetHandler, UnresolvedHandlerInfoByParam } from 'router/route-info';
+import HandlerInfo, { UnresolvedRouteInfoByParam } from 'router/route-info';
 import TransitionAbortedError from 'router/transition-aborted-error';
 import { UnrecognizedURLError } from 'router/unrecognized-url-error';
 import { configure, resolve } from 'rsvp';
@@ -160,10 +160,10 @@ export function createHandlerInfo(name: string, options: Dict<unknown> = {}): Ha
       super(name, router, handler);
     }
     getModel(_transition: Transition) {
-      return {};
+      return {} as any;
     }
     getUnresolved() {
-      return new UnresolvedHandlerInfoByParam('empty', this.router, {});
+      return new UnresolvedRouteInfoByParam('empty', this.router, {});
     }
   }
 

--- a/tests/transition_intent_test.ts
+++ b/tests/transition_intent_test.ts
@@ -7,8 +7,8 @@ import Router, { Route, Transition } from 'router';
 import { Dict } from 'router/core';
 import HandlerInfo, {
   ResolvedRouteInfo,
-  UnresolvedHandlerInfoByObject,
-  UnresolvedHandlerInfoByParam,
+  UnresolvedRouteInfoByObject,
+  UnresolvedRouteInfoByParam,
 } from 'router/route-info';
 import { Promise } from 'rsvp';
 
@@ -168,7 +168,7 @@ scenarios.forEach(function(scenario) {
   test('URLTransitionIntent applied to single unresolved URL handlerInfo', function(assert) {
     let state = new TransitionState();
 
-    let startingHandlerInfo = new UnresolvedHandlerInfoByParam('foo', router, {}, handlers.foo);
+    let startingHandlerInfo = new UnresolvedRouteInfoByParam('foo', router, {}, handlers.foo);
 
     // This single unresolved handler info will be preserved
     // in the new array of handlerInfos.
@@ -188,7 +188,7 @@ scenarios.forEach(function(scenario) {
       "The starting foo handlerInfo wasn't overridden because the new one wasn't any different"
     );
     assert.ok(
-      handlerInfos[1] instanceof UnresolvedHandlerInfoByParam,
+      handlerInfos[1] instanceof UnresolvedRouteInfoByParam,
       'generated state consists of UnresolvedHandlerInfoByParam, 2'
     );
     assertHandlerEquals(assert, handlerInfos[1], handlers.bar);
@@ -212,7 +212,7 @@ scenarios.forEach(function(scenario) {
       "The starting foo resolved handlerInfo wasn't overridden because the new one wasn't any different"
     );
     assert.ok(
-      handlerInfos[1] instanceof UnresolvedHandlerInfoByParam,
+      handlerInfos[1] instanceof UnresolvedRouteInfoByParam,
       'generated state consists of UnresolvedHandlerInfoByParam, 2'
     );
     assertHandlerEquals(assert, handlerInfos[1], handlers.bar);
@@ -242,7 +242,7 @@ scenarios.forEach(function(scenario) {
       'The starting foo resolved handlerInfo was overridden because the new had different params'
     );
     assert.ok(
-      handlerInfos[1] instanceof UnresolvedHandlerInfoByParam,
+      handlerInfos[1] instanceof UnresolvedRouteInfoByParam,
       'generated state consists of UnresolvedHandlerInfoByParam, 2'
     );
 
@@ -266,7 +266,7 @@ scenarios.forEach(function(scenario) {
       'The starting foo resolved handlerInfo gets overridden because the new one has a different name'
     );
     assert.ok(
-      handlerInfos[1] instanceof UnresolvedHandlerInfoByParam,
+      handlerInfos[1] instanceof UnresolvedRouteInfoByParam,
       'generated state consists of UnresolvedHandlerInfoByParam, 2'
     );
     assertHandlerEquals(assert, handlerInfos[1], handlers.bar);
@@ -297,7 +297,7 @@ scenarios.forEach(function(scenario) {
     assert.equal(handlerInfos[0], startingHandlerInfo);
     assert.equal(handlerInfos[0].context, article);
     assert.ok(
-      handlerInfos[1] instanceof UnresolvedHandlerInfoByObject,
+      handlerInfos[1] instanceof UnresolvedRouteInfoByObject,
       'generated state consists of UnresolvedHandlerInfoByObject, 2'
     );
     assert.equal(handlerInfos[1].context, comment);

--- a/tests/transition_intent_test.ts
+++ b/tests/transition_intent_test.ts
@@ -3,17 +3,17 @@ import URLTransitionIntent from 'router/transition-intent/url-transition-intent'
 import TransitionState from 'router/transition-state';
 import { createHandler, module, test } from './test_helpers';
 
-import { IHandler } from 'router';
+import { Route } from 'router';
 import { Dict } from 'router/core';
 import HandlerInfo, {
   noopGetHandler,
-  ResolvedHandlerInfo,
+  ResolvedRouteInfo,
   UnresolvedHandlerInfoByObject,
   UnresolvedHandlerInfoByParam,
-} from 'router/handler-info';
+} from 'router/route-info';
 import { Promise } from 'rsvp';
 
-let handlers: Dict<IHandler>, recognizer: any;
+let handlers: Dict<Route>, recognizer: any;
 
 let scenarios = [
   {
@@ -41,12 +41,12 @@ let scenarios = [
 scenarios.forEach(function(scenario) {
   // Asserts that a handler from a handlerInfo equals an expected valued.
   // Returns a promise during async scenarios to wait until the handler is ready.
-  function assertHandlerEquals(assert: Assert, handlerInfo: HandlerInfo, expected: IHandler) {
+  function assertHandlerEquals(assert: Assert, handlerInfo: HandlerInfo, expected: Route) {
     if (!scenario.async) {
-      return assert.equal(handlerInfo.handler, expected);
+      return assert.equal(handlerInfo.route, expected);
     } else {
-      assert.equal(handlerInfo.handler, undefined);
-      return handlerInfo.handlerPromise.then(function(handler) {
+      assert.equal(handlerInfo.route, undefined);
+      return handlerInfo.routePromise.then(function(handler) {
         assert.equal(handler, expected);
       });
     }
@@ -171,7 +171,7 @@ scenarios.forEach(function(scenario) {
   test('URLTransitionIntent applied to an already-resolved handlerInfo', function(assert) {
     let state = new TransitionState();
 
-    let startingHandlerInfo = new ResolvedHandlerInfo('foo', handlers.foo, {});
+    let startingHandlerInfo = new ResolvedRouteInfo('foo', handlers.foo, {});
 
     state.handlerInfos = [startingHandlerInfo];
 
@@ -197,7 +197,7 @@ scenarios.forEach(function(scenario) {
 
     let article = {};
 
-    let startingHandlerInfo = new ResolvedHandlerInfo(
+    let startingHandlerInfo = new ResolvedRouteInfo(
       'articles',
       createHandler('articles'),
       { article_id: 'some-other-id' },
@@ -225,7 +225,7 @@ scenarios.forEach(function(scenario) {
   test('URLTransitionIntent applied to an already-resolved handlerInfo of different route', function(assert) {
     let state = new TransitionState();
 
-    let startingHandlerInfo = new ResolvedHandlerInfo('alex', handlers.foo, {});
+    let startingHandlerInfo = new ResolvedRouteInfo('alex', handlers.foo, {});
 
     state.handlerInfos = [startingHandlerInfo];
 
@@ -251,7 +251,7 @@ scenarios.forEach(function(scenario) {
     let article = {};
     let comment = {};
 
-    let startingHandlerInfo = new ResolvedHandlerInfo(
+    let startingHandlerInfo = new ResolvedRouteInfo(
       'articles',
       createHandler('articles'),
       { article_id: 'some-other-id' },

--- a/tests/transition_intent_test.ts
+++ b/tests/transition_intent_test.ts
@@ -168,7 +168,7 @@ scenarios.forEach(function(scenario) {
   test('URLTransitionIntent applied to single unresolved URL handlerInfo', function(assert) {
     let state = new TransitionState();
 
-    let startingHandlerInfo = new UnresolvedRouteInfoByParam('foo', router, {}, handlers.foo);
+    let startingHandlerInfo = new UnresolvedRouteInfoByParam(router, 'foo', [], {}, handlers.foo);
 
     // This single unresolved handler info will be preserved
     // in the new array of handlerInfos.
@@ -197,7 +197,7 @@ scenarios.forEach(function(scenario) {
   test('URLTransitionIntent applied to an already-resolved handlerInfo', function(assert) {
     let state = new TransitionState();
 
-    let startingHandlerInfo = new ResolvedRouteInfo('foo', router, handlers.foo, {});
+    let startingHandlerInfo = new ResolvedRouteInfo(router, 'foo', [], {}, handlers.foo);
 
     state.routeInfos = [startingHandlerInfo];
 
@@ -223,10 +223,11 @@ scenarios.forEach(function(scenario) {
     let article = {};
 
     let startingHandlerInfo = new ResolvedRouteInfo(
-      'articles',
       router,
-      createHandler('articles'),
+      'articles',
+      [],
       { article_id: 'some-other-id' },
+      createHandler('articles'),
       article
     );
 
@@ -252,7 +253,7 @@ scenarios.forEach(function(scenario) {
   test('URLTransitionIntent applied to an already-resolved handlerInfo of different route', function(assert) {
     let state = new TransitionState();
 
-    let startingHandlerInfo = new ResolvedRouteInfo('alex', router, handlers.foo, {});
+    let startingHandlerInfo = new ResolvedRouteInfo(router, 'alex', [], {}, handlers.foo);
 
     state.routeInfos = [startingHandlerInfo];
 
@@ -279,10 +280,11 @@ scenarios.forEach(function(scenario) {
     let comment = {};
 
     let startingHandlerInfo = new ResolvedRouteInfo(
-      'articles',
       router,
-      createHandler('articles'),
+      'articles',
+      [],
       { article_id: 'some-other-id' },
+      createHandler('articles'),
       article
     );
 

--- a/tests/transition_intent_test.ts
+++ b/tests/transition_intent_test.ts
@@ -148,7 +148,7 @@ scenarios.forEach(function(scenario) {
     let state = new TransitionState();
     let intent = new URLTransitionIntent('/foo/bar', router);
     let newState = intent.applyToState(state);
-    let handlerInfos = newState.handlerInfos;
+    let handlerInfos = newState.routeInfos;
 
     assert.equal(handlerInfos.length, 2);
     assert.notOk(
@@ -175,11 +175,11 @@ scenarios.forEach(function(scenario) {
     // Reason: if it were resolved, we wouldn't want to replace it.
     // So we only want to replace if it's actually known to be
     // different.
-    state.handlerInfos = [startingHandlerInfo];
+    state.routeInfos = [startingHandlerInfo];
 
     let intent = new URLTransitionIntent('/foo/bar', router);
     let newState = intent.applyToState(state);
-    let handlerInfos = newState.handlerInfos;
+    let handlerInfos = newState.routeInfos;
 
     assert.equal(handlerInfos.length, 2);
     assert.equal(
@@ -199,11 +199,11 @@ scenarios.forEach(function(scenario) {
 
     let startingHandlerInfo = new ResolvedRouteInfo('foo', router, handlers.foo, {});
 
-    state.handlerInfos = [startingHandlerInfo];
+    state.routeInfos = [startingHandlerInfo];
 
     let intent = new URLTransitionIntent('/foo/bar', router);
     let newState = intent.applyToState(state);
-    let handlerInfos = newState.handlerInfos;
+    let handlerInfos = newState.routeInfos;
 
     assert.equal(handlerInfos.length, 2);
     assert.equal(
@@ -230,11 +230,11 @@ scenarios.forEach(function(scenario) {
       article
     );
 
-    state.handlerInfos = [startingHandlerInfo];
+    state.routeInfos = [startingHandlerInfo];
 
     let intent = new URLTransitionIntent('/articles/123/comments/456', router);
     let newState = intent.applyToState(state);
-    let handlerInfos = newState.handlerInfos;
+    let handlerInfos = newState.routeInfos;
 
     assert.equal(handlerInfos.length, 2);
     assert.ok(
@@ -254,11 +254,11 @@ scenarios.forEach(function(scenario) {
 
     let startingHandlerInfo = new ResolvedRouteInfo('alex', router, handlers.foo, {});
 
-    state.handlerInfos = [startingHandlerInfo];
+    state.routeInfos = [startingHandlerInfo];
 
     let intent = new URLTransitionIntent('/foo/bar', router);
     let newState = intent.applyToState(state);
-    let handlerInfos = newState.handlerInfos;
+    let handlerInfos = newState.routeInfos;
 
     assert.equal(handlerInfos.length, 2);
     assert.ok(
@@ -286,12 +286,12 @@ scenarios.forEach(function(scenario) {
       article
     );
 
-    state.handlerInfos = [startingHandlerInfo];
+    state.routeInfos = [startingHandlerInfo];
 
     let intent = new NamedTransitionIntent('comments', router, undefined, [article, comment]);
 
     let newState = intent.applyToState(state, false);
-    let handlerInfos = newState.handlerInfos;
+    let handlerInfos = newState.routeInfos;
 
     assert.equal(handlerInfos.length, 2);
     assert.equal(handlerInfos[0], startingHandlerInfo);

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -5,7 +5,7 @@ import {
   noopGetHandler,
   UnresolvedHandlerInfoByObject,
   UnresolvedHandlerInfoByParam,
-} from 'router/handler-info';
+} from 'router/route-info';
 import TransitionState, { TransitionError } from 'router/transition-state';
 import { Promise, reject, resolve } from 'rsvp';
 import { createHandler, createHandlerInfo, flushBackburner, module, test } from './test_helpers';

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -2,8 +2,8 @@ import { Transition } from 'router';
 import { Dict } from 'router/core';
 import {
   Continuation,
-  UnresolvedHandlerInfoByObject,
-  UnresolvedHandlerInfoByParam,
+  UnresolvedRouteInfoByObject,
+  UnresolvedRouteInfoByParam,
 } from 'router/route-info';
 import TransitionState, { TransitionError } from 'router/transition-state';
 import { Promise, reject, resolve } from 'rsvp';
@@ -101,7 +101,7 @@ test('Integration w/ HandlerInfos', function(assert) {
   let transition = {};
 
   state.handlerInfos = [
-    new UnresolvedHandlerInfoByParam(
+    new UnresolvedRouteInfoByParam(
       'foo',
       router,
       { foo_id: '123' },
@@ -113,7 +113,7 @@ test('Integration w/ HandlerInfos', function(assert) {
         },
       })
     ),
-    new UnresolvedHandlerInfoByObject('bar', ['bar_id'], router, resolve(barModel)),
+    new UnresolvedRouteInfoByObject('bar', ['bar_id'], router, resolve(barModel)),
   ];
 
   function noop() {

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -20,7 +20,7 @@ module('TransitionState');
 
 test('it starts off with default state', function(assert) {
   let state = new TransitionState();
-  assert.deepEqual(state.handlerInfos, [], 'it has an array of handlerInfos');
+  assert.deepEqual(state.routeInfos, [], 'it has an array of handlerInfos');
 });
 
 test("#resolve delegates to handleInfo objects' resolve()", function(assert) {
@@ -32,7 +32,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function(assert) {
 
   let resolvedHandlerInfos: any[] = [{}, {}];
 
-  state.handlerInfos = [
+  state.routeInfos = [
     createHandlerInfo('one', {
       resolve: function(shouldContinue: Continuation) {
         ++counter;
@@ -57,7 +57,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function(assert) {
   }
 
   state.resolve(keepGoing, {} as Transition).then(function(result: TransitionState) {
-    assert.deepEqual(result.handlerInfos, resolvedHandlerInfos);
+    assert.deepEqual(result.routeInfos, resolvedHandlerInfos);
   });
 });
 
@@ -66,7 +66,7 @@ test('State resolution can be halted', function(assert) {
 
   let state = new TransitionState();
 
-  state.handlerInfos = [
+  state.routeInfos = [
     createHandlerInfo('one', {
       resolve: function(shouldContinue: Continuation) {
         return shouldContinue();
@@ -100,7 +100,7 @@ test('Integration w/ HandlerInfos', function(assert) {
   let barModel = {};
   let transition = {};
 
-  state.handlerInfos = [
+  state.routeInfos = [
     new UnresolvedRouteInfoByParam(
       'foo',
       router,
@@ -124,8 +124,8 @@ test('Integration w/ HandlerInfos', function(assert) {
     .resolve(noop, transition as Transition)
     .then(function(result: TransitionState) {
       let models = [];
-      for (let i = 0; i < result.handlerInfos.length; i++) {
-        models.push(result.handlerInfos[i].context);
+      for (let i = 0; i < result.routeInfos.length; i++) {
+        models.push(result.routeInfos[i].context);
       }
 
       assert.equal(models[0], fooModel);

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -102,8 +102,9 @@ test('Integration w/ HandlerInfos', function(assert) {
 
   state.routeInfos = [
     new UnresolvedRouteInfoByParam(
-      'foo',
       router,
+      'foo',
+      ['foo_id'],
       { foo_id: '123' },
       createHandler('foo', {
         model: function(params: Dict<unknown>, payload: Dict<unknown>) {
@@ -113,7 +114,7 @@ test('Integration w/ HandlerInfos', function(assert) {
         },
       })
     ),
-    new UnresolvedRouteInfoByObject('bar', ['bar_id'], router, resolve(barModel)),
+    new UnresolvedRouteInfoByObject(router, 'bar', ['bar_id'], resolve(barModel)),
   ];
 
   function noop() {

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -2,13 +2,19 @@ import { Transition } from 'router';
 import { Dict } from 'router/core';
 import {
   Continuation,
-  noopGetHandler,
   UnresolvedHandlerInfoByObject,
   UnresolvedHandlerInfoByParam,
 } from 'router/route-info';
 import TransitionState, { TransitionError } from 'router/transition-state';
 import { Promise, reject, resolve } from 'rsvp';
-import { createHandler, createHandlerInfo, flushBackburner, module, test } from './test_helpers';
+import {
+  createHandler,
+  createHandlerInfo,
+  flushBackburner,
+  module,
+  StubRouter,
+  test,
+} from './test_helpers';
 
 module('TransitionState');
 
@@ -89,7 +95,7 @@ test('Integration w/ HandlerInfos', function(assert) {
   assert.expect(4);
 
   let state = new TransitionState();
-
+  let router = new StubRouter();
   let fooModel = {};
   let barModel = {};
   let transition = {};
@@ -97,7 +103,7 @@ test('Integration w/ HandlerInfos', function(assert) {
   state.handlerInfos = [
     new UnresolvedHandlerInfoByParam(
       'foo',
-      noopGetHandler,
+      router,
       { foo_id: '123' },
       createHandler('foo', {
         model: function(params: Dict<unknown>, payload: Dict<unknown>) {
@@ -107,13 +113,7 @@ test('Integration w/ HandlerInfos', function(assert) {
         },
       })
     ),
-    new UnresolvedHandlerInfoByObject(
-      'bar',
-      ['bar_id'],
-      noopGetHandler,
-      () => {},
-      resolve(barModel)
-    ),
+    new UnresolvedHandlerInfoByObject('bar', ['bar_id'], router, resolve(barModel)),
   ];
 
   function noop() {


### PR DESCRIPTION
This introduces the public `RouteInfo` type and `from` and `to` fields on the `Transition` as described in https://github.com/emberjs/rfcs/pull/95.

This PR also:
- [Breaking] removes all underscore methods from the `Route` type.
- [Breaking] Renames `HandlerInfo` -> `RouteInfo` in many places.