### PR TITLE
[BREAKING] Generics

### DIFF
--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -1,4 +1,4 @@
 export { default } from './router';
-export { Transition } from './transition';
+export { default as InternalTransition, PublicTransition as Transition } from './transition';
 export { default as TransitionState } from './transition-state';
-export { Route } from './route-info';
+export { default as InternalRouteInfo, RouteInfo, Route } from './route-info';

--- a/lib/router/transition-intent.ts
+++ b/lib/router/transition-intent.ts
@@ -1,14 +1,16 @@
-import { Dict } from './core';
+import { Route } from './route-info';
 import Router from './router';
 import TransitionState from './transition-state';
 
-export abstract class TransitionIntent {
-  data: Dict<unknown>;
-  router: Router;
-  constructor(router: Router, data?: Dict<unknown>) {
+export type OpaqueIntent = TransitionIntent<any>;
+
+export abstract class TransitionIntent<T extends Route> {
+  data: {};
+  router: Router<T>;
+  constructor(router: Router<T>, data: {} = {}) {
     this.router = router;
-    this.data = data || {};
+    this.data = data;
   }
-  preTransitionState?: TransitionState;
-  abstract applyToState(oldState: TransitionState, isIntermidate: boolean): TransitionState;
+  preTransitionState?: TransitionState<T>;
+  abstract applyToState(oldState: TransitionState<T>, isIntermidate: boolean): TransitionState<T>;
 }

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -9,28 +9,29 @@ import { TransitionIntent } from '../transition-intent';
 import TransitionState from '../transition-state';
 import { extractQueryParams, isParam, merge } from '../utils';
 
-export default class NamedTransitionIntent extends TransitionIntent {
+export default class NamedTransitionIntent<T extends Route> extends TransitionIntent<T> {
   name: string;
   pivotHandler?: Route;
   contexts: Dict<unknown>[];
   queryParams: Dict<unknown>;
-  preTransitionState?: TransitionState = undefined;
+  preTransitionState?: TransitionState<T> = undefined;
 
   constructor(
+    router: Router<T>,
     name: string,
-    router: Router,
     pivotHandler: Route | undefined,
     contexts: Dict<unknown>[] = [],
-    queryParams: Dict<unknown> = {}
+    queryParams: Dict<unknown> = {},
+    data?: {}
   ) {
-    super(router);
+    super(router, data);
     this.name = name;
     this.pivotHandler = pivotHandler;
     this.contexts = contexts;
     this.queryParams = queryParams;
   }
 
-  applyToState(oldState: TransitionState, isIntermediate: boolean) {
+  applyToState(oldState: TransitionState<T>, isIntermediate: boolean): TransitionState<T> {
     // TODO: WTF fix me
     let partitionedArgs = extractQueryParams([this.name].concat(this.contexts as any)),
       pureArgs = partitionedArgs[0],
@@ -42,14 +43,14 @@ export default class NamedTransitionIntent extends TransitionIntent {
   }
 
   applyToHandlers(
-    oldState: TransitionState,
+    oldState: TransitionState<T>,
     parsedHandlers: ParsedHandler[],
     targetRouteName: string,
     isIntermediate: boolean,
     checkingIfActive: boolean
   ) {
     let i, len;
-    let newState = new TransitionState();
+    let newState = new TransitionState<T>();
     let objects = this.contexts.slice(0);
 
     let invalidateIndex = parsedHandlers.length;
@@ -140,7 +141,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
     return newState;
   }
 
-  invalidateChildren(handlerInfos: InternalRouteInfo[], invalidateIndex: number) {
+  invalidateChildren(handlerInfos: InternalRouteInfo<T>[], invalidateIndex: number) {
     for (let i = invalidateIndex, l = handlerInfos.length; i < l; ++i) {
       let handlerInfo = handlerInfos[i];
       if (handlerInfo.isResolved) {
@@ -160,7 +161,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
     name: string,
     names: string[],
     objects: Dict<unknown>[],
-    oldHandlerInfo: InternalRouteInfo,
+    oldHandlerInfo: InternalRouteInfo<T>,
     _targetRouteName: string,
     i: number
   ) {
@@ -199,7 +200,7 @@ export default class NamedTransitionIntent extends TransitionIntent {
     name: string,
     names: string[],
     objects: Dict<unknown>[],
-    oldHandlerInfo: InternalRouteInfo
+    oldHandlerInfo: InternalRouteInfo<T>
   ) {
     let params: Dict<unknown> = {};
 

--- a/lib/router/transition-state.ts
+++ b/lib/router/transition-state.ts
@@ -1,15 +1,15 @@
 import { Promise } from 'rsvp';
 import { Dict } from './core';
 import InternalRouteInfo, { Continuation, Route } from './route-info';
-import { Transition } from './transition';
+import Transition from './transition';
 import { forEach, promiseLabel } from './utils';
 
 interface IParams {
   [key: string]: unknown;
 }
 
-export default class TransitionState {
-  routeInfos: InternalRouteInfo[] = [];
+export default class TransitionState<T extends Route> {
+  routeInfos: InternalRouteInfo<T>[] = [];
   queryParams: Dict<unknown> = {};
   params: IParams = {};
 
@@ -25,7 +25,7 @@ export default class TransitionState {
     return promiseLabel("'" + targetName + "': " + label);
   }
 
-  resolve(shouldContinue: Continuation, transition: Transition): Promise<TransitionState> {
+  resolve(shouldContinue: Continuation, transition: Transition<T>): Promise<TransitionState<T>> {
     // First, calculate params for this state. This is useful
     // information to provide to the various route hooks.
     let params = this.params;
@@ -75,7 +75,7 @@ export default class TransitionState {
       );
     }
 
-    function proceed(resolvedRouteInfo: InternalRouteInfo): Promise<InternalRouteInfo> {
+    function proceed(resolvedRouteInfo: InternalRouteInfo<T>): Promise<InternalRouteInfo<T>> {
       let wasAlreadyResolved = currentState.routeInfos[transition.resolveIndex].isResolved;
 
       // Swap the previously unresolved routeInfo with
@@ -104,7 +104,7 @@ export default class TransitionState {
       );
     }
 
-    function resolveOneRouteInfo(): TransitionState | Promise<any> {
+    function resolveOneRouteInfo(): TransitionState<T> | Promise<any> {
       if (transition.resolveIndex === currentState.routeInfos.length) {
         // This is is the only possible
         // fulfill value of TransitionState#resolve
@@ -125,6 +125,6 @@ export class TransitionError {
     public error: Error,
     public route: Route,
     public wasAborted: boolean,
-    public state: TransitionState
+    public state: TransitionState<any>
   ) {}
 }

--- a/lib/router/utils.ts
+++ b/lib/router/utils.ts
@@ -66,7 +66,7 @@ export function coerceQueryParamsToString(queryParams: Dict<unknown>) {
 /**
   @private
  */
-export function log(router: Router, ...args: (string | number)[]): void {
+export function log(router: Router<any>, ...args: (string | number)[]): void {
   if (!router.log) {
     return;
   }

--- a/lib/rsvp/index.d.ts
+++ b/lib/rsvp/index.d.ts
@@ -21,14 +21,14 @@ declare module 'rsvp' {
     | undefined
     | null;
   export type OnRejected<T, TResult2> =
-    | ((reason: T) => TResult2 | PromiseLike<TResult2>)
+    | ((reason: any) => TResult2 | PromiseLike<TResult2>)
     | undefined
     | null;
 
   export interface Promise<T> extends PromiseLike<T> {
     then<TResult1 = T, TResult2 = never>(
-      onFulfilled?: OnFulfilled<T, TResult1>,
-      onRejected?: OnRejected<T, TResult2>,
+      onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+      onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
       label?: string
     ): Promise<TResult1 | TResult2>;
     catch<TResult = never>(

--- a/tests/async_get_handler_test.ts
+++ b/tests/async_get_handler_test.ts
@@ -7,14 +7,14 @@ import { createHandler } from './test_helpers';
 // so that we avoid using Backburner to handle the async portions of
 // the test suite
 let handlers: Dict<Route>;
-let router: Router;
+let router: Router<Route>;
 QUnit.module('Async Get Handler', {
   beforeEach: function() {
     QUnit.config.testTimeout = 60000;
 
     handlers = {};
 
-    class TestRouter extends Router {
+    class TestRouter extends Router<Route> {
       didTransition() {}
       willTransition() {}
       replaceURL() {}
@@ -119,5 +119,5 @@ QUnit.test('calls hooks of lazily-resolved routes in order', function(assert) {
       'order of operations is correct'
     );
     done();
-  });
+  }, null);
 });

--- a/tests/handler_info_test.ts
+++ b/tests/handler_info_test.ts
@@ -1,7 +1,8 @@
 import { Transition } from 'router';
 import { Dict } from 'router/core';
-import HandlerInfo, {
+import RouteInfo, {
   ResolvedRouteInfo,
+  Route,
   UnresolvedRouteInfoByObject,
   UnresolvedRouteInfoByParam,
 } from 'router/route-info';
@@ -52,7 +53,7 @@ test('HandlerInfo#resolve resolves with a ResolvedHandlerInfo', function(assert)
   let handlerInfo = createHandlerInfo('stub');
   handlerInfo
     .resolve(() => false, {} as Transition)
-    .then(function(resolvedHandlerInfo: HandlerInfo) {
+    .then(function(resolvedHandlerInfo: RouteInfo<Route>) {
       assert.ok(resolvedHandlerInfo instanceof ResolvedRouteInfo);
     });
 });
@@ -112,7 +113,7 @@ test('HandlerInfo#resolve runs afterModel hook on handler', function(assert) {
 
   handlerInfo
     .resolve(noop, transition as Transition)
-    .then(function(resolvedHandlerInfo: HandlerInfo) {
+    .then(function(resolvedHandlerInfo: RouteInfo<Route>) {
       assert.equal(resolvedHandlerInfo.context, model, 'HandlerInfo resolved with correct model');
     });
 });
@@ -145,21 +146,21 @@ test('UnresolvedHandlerInfoByParam gets its model hook called', function(assert)
 test('UnresolvedHandlerInfoByObject does NOT get its model hook called', function(assert) {
   assert.expect(1);
 
-  class Handler extends UnresolvedRouteInfoByObject {
+  class TestRouteInfo extends UnresolvedRouteInfoByObject<Route> {
     route = createHandler('uresolved', {
       model: function() {
         assert.ok(false, "I shouldn't be called because I already have a context/model");
       },
     });
   }
-  let handlerInfo = new Handler(
+  let routeInfo = new TestRouteInfo(
     new StubRouter(),
     'unresolved',
     ['wat'],
     resolve({ name: 'dorkletons' })
   );
 
-  handlerInfo.resolve(noop, {} as Transition).then(function(resolvedHandlerInfo: HandlerInfo) {
+  routeInfo.resolve(noop, {} as Transition).then(function(resolvedHandlerInfo: RouteInfo<Route>) {
     assert.equal(resolvedHandlerInfo.context!.name, 'dorkletons');
   });
 });

--- a/tests/query_params_test.ts
+++ b/tests/query_params_test.ts
@@ -1,7 +1,7 @@
 import { MatchCallback } from 'route-recognizer';
 import Router, { Route, Transition } from 'router';
 import { Dict, Maybe } from 'router/core';
-import HandlerInfo from 'router/route-info';
+import RouteInfo from 'router/route-info';
 import { Promise } from 'rsvp';
 import {
   createHandler,
@@ -12,7 +12,7 @@ import {
   trigger,
 } from './test_helpers';
 
-let router: Router, handlers: Dict<Route>, expectedUrl: Maybe<string>;
+let router: Router<Route>, handlers: Dict<Route>, expectedUrl: Maybe<string>;
 let scenarios = [
   {
     name: 'Sync Get Handler',
@@ -45,10 +45,15 @@ scenarios.forEach(function(scenario) {
   });
 
   function map(assert: Assert, fn: MatchCallback) {
-    class TestRouter extends Router {
+    class TestRouter extends Router<Route> {
       didTransition() {}
       willTransition() {}
-      triggerEvent(handlerInfos: HandlerInfo[], ignoreFailure: boolean, name: string, args: any[]) {
+      triggerEvent(
+        handlerInfos: RouteInfo<Route>[],
+        ignoreFailure: boolean,
+        name: string,
+        args: any[]
+      ) {
         trigger(handlerInfos, ignoreFailure, name, ...args);
       }
       replaceURL(name: string) {

--- a/tests/transition_intent_test.ts
+++ b/tests/transition_intent_test.ts
@@ -5,7 +5,7 @@ import { createHandler, module, test } from './test_helpers';
 
 import Router, { Route, Transition } from 'router';
 import { Dict } from 'router/core';
-import HandlerInfo, {
+import InternalRouteInfo, {
   ResolvedRouteInfo,
   UnresolvedRouteInfoByObject,
   UnresolvedRouteInfoByParam,
@@ -32,7 +32,7 @@ let scenarios = [
 ];
 
 scenarios.forEach(function(scenario) {
-  class TestRouter extends Router {
+  class TestRouter extends Router<Route> {
     getSerializer(_name: string) {
       return () => {};
     }
@@ -43,17 +43,17 @@ scenarios.forEach(function(scenario) {
       throw new Error('Method not implemented.');
     }
     willTransition(
-      _oldHandlerInfos: HandlerInfo[],
-      _newHandlerInfos: HandlerInfo[],
+      _oldHandlerInfos: InternalRouteInfo<Route>[],
+      _newHandlerInfos: InternalRouteInfo<Route>[],
       _transition: Transition
     ): void {
       throw new Error('Method not implemented.');
     }
-    didTransition(_handlerInfos: HandlerInfo[]): void {
+    didTransition(_handlerInfos: InternalRouteInfo<Route>[]): void {
       throw new Error('Method not implemented.');
     }
     triggerEvent(
-      _handlerInfos: HandlerInfo[],
+      _handlerInfos: InternalRouteInfo<Route>[],
       _ignoreFailure: boolean,
       _name: string,
       _args: unknown[]
@@ -65,11 +65,15 @@ scenarios.forEach(function(scenario) {
     }
   }
 
-  let router: Router;
+  let router: Router<Route>;
 
   // Asserts that a handler from a handlerInfo equals an expected valued.
   // Returns a promise during async scenarios to wait until the handler is ready.
-  function assertHandlerEquals(assert: Assert, handlerInfo: HandlerInfo, expected: Route) {
+  function assertHandlerEquals(
+    assert: Assert,
+    handlerInfo: InternalRouteInfo<Route>,
+    expected: Route
+  ) {
     if (!scenario.async) {
       return assert.equal(handlerInfo.route, expected);
     } else {
@@ -146,7 +150,7 @@ scenarios.forEach(function(scenario) {
 
   test('URLTransitionIntent can be applied to an empty state', function(assert) {
     let state = new TransitionState();
-    let intent = new URLTransitionIntent('/foo/bar', router);
+    let intent = new URLTransitionIntent(router, '/foo/bar');
     let newState = intent.applyToState(state);
     let handlerInfos = newState.routeInfos;
 
@@ -177,7 +181,7 @@ scenarios.forEach(function(scenario) {
     // different.
     state.routeInfos = [startingHandlerInfo];
 
-    let intent = new URLTransitionIntent('/foo/bar', router);
+    let intent = new URLTransitionIntent(router, '/foo/bar');
     let newState = intent.applyToState(state);
     let handlerInfos = newState.routeInfos;
 
@@ -201,7 +205,7 @@ scenarios.forEach(function(scenario) {
 
     state.routeInfos = [startingHandlerInfo];
 
-    let intent = new URLTransitionIntent('/foo/bar', router);
+    let intent = new URLTransitionIntent(router, '/foo/bar');
     let newState = intent.applyToState(state);
     let handlerInfos = newState.routeInfos;
 
@@ -233,7 +237,7 @@ scenarios.forEach(function(scenario) {
 
     state.routeInfos = [startingHandlerInfo];
 
-    let intent = new URLTransitionIntent('/articles/123/comments/456', router);
+    let intent = new URLTransitionIntent(router, '/articles/123/comments/456');
     let newState = intent.applyToState(state);
     let handlerInfos = newState.routeInfos;
 
@@ -257,7 +261,7 @@ scenarios.forEach(function(scenario) {
 
     state.routeInfos = [startingHandlerInfo];
 
-    let intent = new URLTransitionIntent('/foo/bar', router);
+    let intent = new URLTransitionIntent(router, '/foo/bar');
     let newState = intent.applyToState(state);
     let handlerInfos = newState.routeInfos;
 
@@ -290,7 +294,7 @@ scenarios.forEach(function(scenario) {
 
     state.routeInfos = [startingHandlerInfo];
 
-    let intent = new NamedTransitionIntent('comments', router, undefined, [article, comment]);
+    let intent = new NamedTransitionIntent(router, 'comments', undefined, [article, comment]);
 
     let newState = intent.applyToState(state, false);
     let handlerInfos = newState.routeInfos;

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -2,6 +2,7 @@ import { Transition } from 'router';
 import { Dict } from 'router/core';
 import {
   Continuation,
+  Route,
   UnresolvedRouteInfoByObject,
   UnresolvedRouteInfoByParam,
 } from 'router/route-info';
@@ -56,7 +57,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function(assert) {
     return Promise.resolve(false);
   }
 
-  state.resolve(keepGoing, {} as Transition).then(function(result: TransitionState) {
+  state.resolve(keepGoing, {} as Transition).then(function(result: TransitionState<Route>) {
     assert.deepEqual(result.routeInfos, resolvedHandlerInfos);
   });
 });
@@ -123,7 +124,7 @@ test('Integration w/ HandlerInfos', function(assert) {
 
   state
     .resolve(noop, transition as Transition)
-    .then(function(result: TransitionState) {
+    .then(function(result: TransitionState<Route>) {
       let models = [];
       for (let i = 0; i < result.routeInfos.length; i++) {
         models.push(result.routeInfos[i].context);


### PR DESCRIPTION
This makes the abstract router class generic over a type that extends the `Route` interface. This allows consumers like Ember to get the type feed back through out its implementation.