### PR TITLE
Add routeWillChange, routeDidChange, transitionDidError

### DIFF
--- a/lib/router/transition-intent/url-transition-intent.ts
+++ b/lib/router/transition-intent/url-transition-intent.ts
@@ -16,7 +16,6 @@ export default class URLTransitionIntent<T extends Route> extends TransitionInte
 
   applyToState(oldState: TransitionState<T>) {
     let newState = new TransitionState<T>();
-
     let results = this.router.recognizer.recognize(this.url),
       i,
       len;

--- a/tests/async_get_handler_test.ts
+++ b/tests/async_get_handler_test.ts
@@ -1,42 +1,27 @@
-import Router, { Route } from 'router';
+import { Route } from 'router';
 import { Dict } from 'router/core';
 import { Promise } from 'rsvp';
-import { createHandler } from './test_helpers';
+import { createHandler, TestRouter } from './test_helpers';
+
+function map(router: TestRouter) {
+  router.map(function(match) {
+    match('/index').to('index');
+    match('/foo').to('foo', function(match) {
+      match('/').to('fooIndex');
+      match('/bar').to('fooBar');
+    });
+  });
+}
 
 // Intentionally use QUnit.module instead of module from test_helpers
 // so that we avoid using Backburner to handle the async portions of
 // the test suite
-let handlers: Dict<Route>;
-let router: Router<Route>;
+let routes: Dict<Route>;
+let router: TestRouter;
 QUnit.module('Async Get Handler', {
   beforeEach: function() {
     QUnit.config.testTimeout = 60000;
-
-    handlers = {};
-
-    class TestRouter extends Router<Route> {
-      didTransition() {}
-      willTransition() {}
-      replaceURL() {}
-      triggerEvent() {}
-      getRoute(_name: string): never {
-        throw new Error('never');
-      }
-
-      getSerializer(_name: string): never {
-        throw new Error('never');
-      }
-
-      updateURL(_name: string) {}
-    }
-    router = new TestRouter();
-    router.map(function(match) {
-      match('/index').to('index');
-      match('/foo').to('foo', function(match) {
-        match('/').to('fooIndex');
-        match('/bar').to('fooBar');
-      });
-    });
+    routes = {};
   },
 
   afterEach: function() {
@@ -47,23 +32,28 @@ QUnit.module('Async Get Handler', {
 QUnit.test('can transition to lazily-resolved routes', function(assert) {
   let done = assert.async();
 
-  router.getRoute = function(name: string) {
-    return new Promise(function(resolve) {
-      setTimeout(function() {
-        resolve(handlers[name] || (handlers[name] = createHandler('empty')));
-      }, 1);
-    });
-  };
+  class LazyRouter extends TestRouter {
+    getRoute(name: string) {
+      return new Promise(function(resolve) {
+        setTimeout(function() {
+          resolve(routes[name] || (routes[name] = createHandler('empty')));
+        }, 1);
+      });
+    }
+  }
+
+  router = new LazyRouter();
+  map(router);
 
   let fooCalled = false;
   let fooBarCalled = false;
 
-  handlers.foo = createHandler('foo', {
+  routes.foo = createHandler('foo', {
     model() {
       fooCalled = true;
     },
   });
-  handlers.fooBar = createHandler('fooBar', {
+  routes.fooBar = createHandler('fooBar', {
     model: function() {
       fooBarCalled = true;
     },
@@ -83,23 +73,28 @@ QUnit.test('calls hooks of lazily-resolved routes in order', function(assert) {
   let done = assert.async();
   let operations: string[] = [];
 
-  router.getRoute = function(name: string) {
-    operations.push('get handler ' + name);
-    return new Promise(function(resolve) {
-      let timeoutLength = name === 'foo' ? 100 : 1;
-      setTimeout(function() {
-        operations.push('resolved ' + name);
-        resolve(handlers[name] || (handlers[name] = createHandler('empty')));
-      }, timeoutLength);
-    });
-  };
+  class LazyRouter extends TestRouter {
+    getRoute(name: string) {
+      operations.push('get handler ' + name);
+      return new Promise(function(resolve) {
+        let timeoutLength = name === 'foo' ? 100 : 1;
+        setTimeout(function() {
+          operations.push('resolved ' + name);
+          resolve(routes[name] || (routes[name] = createHandler('empty')));
+        }, timeoutLength);
+      });
+    }
+  }
 
-  handlers.foo = createHandler('foo', {
+  router = new LazyRouter();
+  map(router);
+
+  routes.foo = createHandler('foo', {
     model: function() {
       operations.push('model foo');
     },
   });
-  handlers.fooBar = createHandler('fooBar', {
+  routes.fooBar = createHandler('fooBar', {
     model: function() {
       operations.push('model fooBar');
     },

--- a/tests/handler_info_test.ts
+++ b/tests/handler_info_test.ts
@@ -6,8 +6,10 @@ import RouteInfo, {
   UnresolvedRouteInfoByObject,
   UnresolvedRouteInfoByParam,
 } from 'router/route-info';
+import InternalTransition from 'router/transition';
+import URLTransitionIntent from 'router/transition-intent/url-transition-intent';
 import { reject, resolve } from 'rsvp';
-import { createHandler, createHandlerInfo, module, StubRouter, test } from './test_helpers';
+import { createHandler, createHandlerInfo, module, test, TestRouter } from './test_helpers';
 
 function noop() {
   return resolve(true);
@@ -16,15 +18,18 @@ function noop() {
 module('HandlerInfo');
 
 test('ResolvedHandlerInfos resolve to themselves', function(assert) {
-  let router = new StubRouter();
+  let router = new TestRouter();
   let handlerInfo = new ResolvedRouteInfo(router, 'foo', [], {}, createHandler('empty'));
-  handlerInfo.resolve().then(function(resolvedHandlerInfo) {
-    assert.equal(handlerInfo, resolvedHandlerInfo);
-  });
+  let intent = new URLTransitionIntent(router, 'foo');
+  handlerInfo
+    .resolve(() => false, new InternalTransition(router, intent, undefined))
+    .then(function(resolvedHandlerInfo) {
+      assert.equal(handlerInfo, resolvedHandlerInfo);
+    });
 });
 
 test('UnresolvedHandlerInfoByParam defaults params to {}', function(assert) {
-  let router = new StubRouter();
+  let router = new TestRouter();
   let handlerInfo = new UnresolvedRouteInfoByParam(router, 'empty', [], {});
   assert.deepEqual(handlerInfo.params, {});
 
@@ -120,7 +125,7 @@ test('HandlerInfo#resolve runs afterModel hook on handler', function(assert) {
 
 test('UnresolvedHandlerInfoByParam gets its model hook called', function(assert) {
   assert.expect(2);
-  let router = new StubRouter();
+  let router = new TestRouter();
 
   let transition = {};
 
@@ -154,7 +159,7 @@ test('UnresolvedHandlerInfoByObject does NOT get its model hook called', functio
     });
   }
   let routeInfo = new TestRouteInfo(
-    new StubRouter(),
+    new TestRouter(),
     'unresolved',
     ['wat'],
     resolve({ name: 'dorkletons' })

--- a/tests/query_params_test.ts
+++ b/tests/query_params_test.ts
@@ -8,6 +8,7 @@ import {
   flushBackburner,
   module,
   test,
+  TestRouter,
   transitionTo,
   trigger,
 } from './test_helpers';
@@ -45,7 +46,9 @@ scenarios.forEach(function(scenario) {
   });
 
   function map(assert: Assert, fn: MatchCallback) {
-    class TestRouter extends Router<Route> {
+    class QPRouter extends TestRouter {
+      routeDidChange() {}
+      routeWillChange() {}
       didTransition() {}
       willTransition() {}
       triggerEvent(
@@ -71,7 +74,7 @@ scenarios.forEach(function(scenario) {
         }
       }
     }
-    router = new TestRouter();
+    router = new QPRouter();
     router.map(fn);
   }
 

--- a/tests/transition_intent_test.ts
+++ b/tests/transition_intent_test.ts
@@ -1,9 +1,9 @@
 import NamedTransitionIntent from 'router/transition-intent/named-transition-intent';
 import URLTransitionIntent from 'router/transition-intent/url-transition-intent';
 import TransitionState from 'router/transition-state';
-import { createHandler, module, test } from './test_helpers';
+import { createHandler, module, test, TestRouter } from './test_helpers';
 
-import Router, { Route, Transition } from 'router';
+import Router, { Route } from 'router';
 import { Dict } from 'router/core';
 import InternalRouteInfo, {
   ResolvedRouteInfo,
@@ -32,34 +32,7 @@ let scenarios = [
 ];
 
 scenarios.forEach(function(scenario) {
-  class TestRouter extends Router<Route> {
-    getSerializer(_name: string) {
-      return () => {};
-    }
-    updateURL(_url: string): void {
-      throw new Error('Method not implemented.');
-    }
-    replaceURL(_url: string): void {
-      throw new Error('Method not implemented.');
-    }
-    willTransition(
-      _oldHandlerInfos: InternalRouteInfo<Route>[],
-      _newHandlerInfos: InternalRouteInfo<Route>[],
-      _transition: Transition
-    ): void {
-      throw new Error('Method not implemented.');
-    }
-    didTransition(_handlerInfos: InternalRouteInfo<Route>[]): void {
-      throw new Error('Method not implemented.');
-    }
-    triggerEvent(
-      _handlerInfos: InternalRouteInfo<Route>[],
-      _ignoreFailure: boolean,
-      _name: string,
-      _args: unknown[]
-    ): void {
-      throw new Error('Method not implemented.');
-    }
+  class TransitionRouter extends TestRouter {
     getRoute(name: string) {
       return scenario.getHandler(name);
     }
@@ -143,7 +116,7 @@ scenarios.forEach(function(scenario) {
         },
       };
 
-      router = new TestRouter();
+      router = new TransitionRouter();
       router.recognizer = recognizer;
     },
   });

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -13,8 +13,8 @@ import {
   createHandlerInfo,
   flushBackburner,
   module,
-  StubRouter,
   test,
+  TestRouter,
 } from './test_helpers';
 
 module('TransitionState');
@@ -96,7 +96,7 @@ test('Integration w/ HandlerInfos', function(assert) {
   assert.expect(4);
 
   let state = new TransitionState();
-  let router = new StubRouter();
+  let router = new TestRouter();
   let fooModel = {};
   let barModel = {};
   let transition = {};


### PR DESCRIPTION
This introduces two new event types `routeWillChange` and `routeDidChange`. These events are specified by the [Router Service RFC](https://github.com/emberjs/rfcs/blob/master/text/0095-router-service.md#new-events-routewillchange--routedidchange). Unlike the `willTransition` and `didTransition` hooks the new events see all transition events including aborts and errors.

In the case of the error we have always aborted the transition. However, the mechanics here are somewhat problematic since calling `abort` will result in a `routeWillChange` event. To deal with this reality, we have decoupled `abort` from the functionality that rolled back the state of the transition. We have also forced the implementer to handle the transition error. In doing so the host can decide how to handle the error and if it should beacon the events.

In practice, Ember will likely just `rollback` the transition if there is an error substate and `abort` if thee isn't a substate. 