### PR TITLE
Fix clobbering issue with `reset`

### DIFF
--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -28,7 +28,7 @@ export interface Route {
   setup?(context: Dict<unknown>, transition: Transition): void;
   enter?(transition: Transition): void;
   exit?(transition?: Transition): void;
-  reset?(wasReset: boolean, transition?: Transition): void;
+  _internalReset?(wasReset: boolean, transition?: Transition): void;
   contextDidChange?(): void;
   redirect?(context: Dict<unknown>, transition: Transition): void;
 }

--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -369,8 +369,8 @@ export default abstract class Router<T extends Route> {
       delete route!.context;
 
       if (route !== undefined) {
-        if (route.reset !== undefined) {
-          route.reset(true, transition);
+        if (route._internalReset !== undefined) {
+          route._internalReset(true, transition);
         }
 
         if (route.exit !== undefined) {
@@ -387,8 +387,8 @@ export default abstract class Router<T extends Route> {
       for (i = 0, l = partition.reset.length; i < l; i++) {
         route = partition.reset[i].route;
         if (route !== undefined) {
-          if (route.reset !== undefined) {
-            route.reset(false, transition);
+          if (route._internalReset !== undefined) {
+            route._internalReset(false, transition);
           }
         }
       }


### PR DESCRIPTION
Having a `reset` method on a route could very likely clobber some user space implementation. This is likely a better name for the framework defined hook.