### PR TITLE
Use 'symbols' for accessing state on transition

### DIFF
--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -3,6 +3,9 @@ export {
   default as InternalTransition,
   PublicTransition as Transition,
   logAbort,
+  STATE_SYMBOL,
+  PARAMS_SYMBOL,
+  QUERY_PARAMS_SYMBOL,
 } from './transition';
 export { default as TransitionState, TransitionError } from './transition-state';
 export { default as InternalRouteInfo, RouteInfo, Route } from './route-info';

--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -3,8 +3,10 @@ import { Dict, Option } from './core';
 import Router, { SerializerFunc } from './router';
 import InternalTransition, {
   isTransition,
+  PARAMS_SYMBOL,
   prepareResult,
   PublicTransition as Transition,
+  QUERY_PARAMS_SYMBOL,
 } from './transition';
 import { isParam, isPromise, merge } from './utils';
 
@@ -190,8 +192,8 @@ export default class InternalRouteInfo<T extends Route> {
 
     if (transition) {
       this.stashResolvedModel(transition, resolvedContext);
-      transition.params = transition.params || {};
-      transition.params[this.name] = params;
+      transition[PARAMS_SYMBOL] = transition[PARAMS_SYMBOL] || {};
+      transition[PARAMS_SYMBOL][this.name] = params;
     }
 
     let context;
@@ -401,10 +403,10 @@ export class UnresolvedRouteInfoByParam<T extends Route> extends InternalRouteIn
 
   getModel(transition: InternalTransition<T>) {
     let fullParams = this.params;
-    if (transition && transition.queryParams) {
+    if (transition && transition[QUERY_PARAMS_SYMBOL]) {
       fullParams = {};
       merge(fullParams, this.params);
-      fullParams.queryParams = transition.queryParams;
+      fullParams.queryParams = transition[QUERY_PARAMS_SYMBOL];
     }
 
     let route = this.route!;

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -19,6 +19,10 @@ export type OnRejected<T, TResult2> =
 export type PublicTransition = Transition<any>;
 export type OpaqueTransition = PublicTransition;
 
+export const STATE_SYMBOL = `__STATE__-2619860001345920-3322w3`;
+export const PARAMS_SYMBOL = `__PARAMS__-261986232992830203-23323`;
+export const QUERY_PARAMS_SYMBOL = `__QPS__-2619863929824844-32323`;
+
 /**
   A Transition is a thennable (a promise-like object) that represents
   an attempt to transition to another route. It can be aborted, either
@@ -35,17 +39,17 @@ export type OpaqueTransition = PublicTransition;
   @private
  */
 export default class Transition<T extends Route> implements Partial<Promise<T>> {
-  state?: TransitionState<T>;
+  [STATE_SYMBOL]: TransitionState<T>;
   from?: RouteInfo = undefined;
   to?: RouteInfo = undefined;
   router: Router<T>;
   data: Dict<unknown>;
   intent: Maybe<OpaqueIntent>;
   resolvedModels: Dict<Dict<unknown>>;
-  queryParams: Dict<unknown>;
+  [QUERY_PARAMS_SYMBOL]: Dict<unknown>;
   promise?: Promise<any>; // Todo: Fix this shit its actually TransitionState | IHandler | undefined | Error
   error: Maybe<Error>;
-  params: Dict<unknown>;
+  [PARAMS_SYMBOL]: Dict<unknown>;
   routeInfos: InternalRouteInfo<Route>[];
   targetName: Maybe<string>;
   pivotHandler: Maybe<Route>;
@@ -68,15 +72,15 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
     error: Maybe<Error> = undefined,
     previousTransition: Maybe<Transition<T>> = undefined
   ) {
-    this.state = state || router.state;
+    this[STATE_SYMBOL] = state! || router.state!;
     this.intent = intent;
     this.router = router;
     this.data = (intent && intent.data) || {};
     this.resolvedModels = {};
-    this.queryParams = {};
+    this[QUERY_PARAMS_SYMBOL] = {};
     this.promise = undefined;
     this.error = undefined;
-    this.params = {};
+    this[PARAMS_SYMBOL] = {};
     this.routeInfos = [];
     this.targetName = undefined;
     this.pivotHandler = undefined;
@@ -104,8 +108,8 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
           previousTransition.isCausedByAbortingReplaceTransition));
 
     if (state) {
-      this.params = state.params;
-      this.queryParams = state.queryParams;
+      this[PARAMS_SYMBOL] = state.params;
+      this[QUERY_PARAMS_SYMBOL] = state.queryParams;
       this.routeInfos = state.routeInfos;
 
       let len = state.routeInfos.length;
@@ -136,8 +140,8 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
           return Promise.reject(this.router.transitionDidError(result, this));
         }, promiseLabel('Handle Abort'));
     } else {
-      this.promise = Promise.resolve(this.state!);
-      this.params = {};
+      this.promise = Promise.resolve(this[STATE_SYMBOL]!);
+      this[PARAMS_SYMBOL] = {};
     }
   }
 
@@ -340,7 +344,7 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
    */
   trigger(ignoreFailure: boolean, name: string, ...args: any[]) {
     this.router.triggerEvent(
-      this.state!.routeInfos.slice(0, this.resolveIndex + 1),
+      this[STATE_SYMBOL]!.routeInfos.slice(0, this.resolveIndex + 1),
       ignoreFailure,
       name,
       args

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -3,7 +3,7 @@ import Router, { Route, Transition } from 'router';
 import { Dict, Maybe } from 'router/core';
 import RouteInfo, { RouteInfoWithAttributes } from 'router/route-info';
 import { SerializerFunc } from 'router/router';
-import { logAbort } from 'router/transition';
+import { logAbort, PARAMS_SYMBOL, QUERY_PARAMS_SYMBOL, STATE_SYMBOL } from 'router/transition';
 import { TransitionError } from 'router/transition-state';
 import { Promise, reject } from 'rsvp';
 import {
@@ -201,7 +201,7 @@ scenarios.forEach(function(scenario) {
     routes = {
       index: createHandler('index', {
         model: function(_params: string[], transition: Transition) {
-          assert.deepEqual(transition.queryParams, {
+          assert.deepEqual(transition[QUERY_PARAMS_SYMBOL], {
             sort: 'date',
             filter: 'true',
           });
@@ -2523,7 +2523,7 @@ scenarios.forEach(function(scenario) {
     routes = {
       postIndex: createHandler('postIndex', {
         model: function(_params: Dict<unknown>, transition: Transition) {
-          assert.deepEqual(transition.params, {
+          assert.deepEqual(transition[PARAMS_SYMBOL], {
             postIndex: {},
             showFilteredPosts: { filter_id: 'sad' },
           });
@@ -2531,7 +2531,7 @@ scenarios.forEach(function(scenario) {
       }),
       showFilteredPosts: createHandler('showFilteredPosts', {
         model: function(_params: Dict<unknown>, transition: Transition) {
-          assert.deepEqual(transition.params, {
+          assert.deepEqual(transition[PARAMS_SYMBOL], {
             postIndex: {},
             showFilteredPosts: { filter_id: 'sad' },
           });
@@ -2602,7 +2602,7 @@ scenarios.forEach(function(scenario) {
 
     // Get a reference to the transition, mid-transition.
     router.willTransition = function() {
-      let midTransitionState = router.activeTransition!.state;
+      let midTransitionState = router.activeTransition![STATE_SYMBOL];
 
       // Make sure that the activeIntent doesn't match post 300.
       let isPost300Targeted = router.isActiveIntent(


### PR DESCRIPTION
We want to be able to discourage touch state on the transition objects and force people to use the public `RouteInfo` objects. To achieve this we need to have a privileged way of accessing the state. In Ember we will install a getter on the transition and tell them to just use the router service when they access the state.