### PR TITLE
[BUGFIX] url should be correct in the hooks

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -137,8 +137,8 @@ export default abstract class Router<T extends Route> {
       newTransition.promise = newTransition.promise!.then(
         (result: TransitionState<T> | Route | Error | undefined) => {
           this._updateURL(newTransition, oldState);
-          this.routeDidChange(newTransition);
           this.didTransition(this.currentRouteInfos!);
+          this.routeDidChange(newTransition);
           return result;
         },
         null,
@@ -356,8 +356,8 @@ export default abstract class Router<T extends Route> {
       this.activeTransition = undefined;
 
       this.triggerEvent(this.currentRouteInfos!, true, 'didTransition', []);
-      this.routeDidChange(transition);
       this.didTransition(this.currentRouteInfos!);
+      this.routeDidChange(transition);
 
       log(this, transition.sequence, 'TRANSITION COMPLETE.');
 

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -26,7 +26,7 @@ import {
 } from './test_helpers';
 
 let router: Router<Route>;
-let url: string;
+let url: string | undefined;
 let routes: Dict<Route>;
 
 function isPresent(maybe: Maybe<PublicRouteInfo>): maybe is PublicRouteInfo {
@@ -64,6 +64,7 @@ scenarios.forEach(function(scenario) {
     setup: function(assert: Assert) {
       routes = {};
       expectedUrl = undefined;
+      url = undefined;
 
       map(assert, function(match) {
         match('/index').to('index');
@@ -490,7 +491,7 @@ scenarios.forEach(function(scenario) {
   });
 
   test('basic route change events with params', function(assert) {
-    assert.expect(18);
+    assert.expect(22);
     map(assert, function(match) {
       match('/').to('index');
       match('/posts/:id').to('post');
@@ -511,9 +512,11 @@ scenarios.forEach(function(scenario) {
         assert.equal(transition.to!.localName, 'post');
         assert.equal(isPresent(transition.from) && transition.from.localName, 'post');
         assert.deepEqual(transition.to!.params, { id: '2' });
+        assert.equal(url, '/posts/1');
       } else {
         assert.equal(transition.to!.localName, 'post');
         assert.equal(transition.from, null);
+        assert.notOk(url);
         assert.deepEqual(transition.to!.params, { id: '1' });
       }
     };
@@ -525,9 +528,11 @@ scenarios.forEach(function(scenario) {
         assert.equal(transition.to!.localName, 'post');
         assert.equal(isPresent(transition.from) && transition.from.localName, 'post');
         assert.deepEqual(transition.to!.params, { id: '2' });
+        assert.equal(url, '/posts/2');
       } else {
         assert.equal(transition.to!.localName, 'post');
         assert.equal(transition.from, null);
+        assert.equal(url, '/posts/1');
         assert.deepEqual(transition.to!.params, { id: '1' });
       }
     };


### PR DESCRIPTION
Prior to this bugfix the URL was not correct in `routeDidChange` events since `didTransition` is used to update the state of the world.