### PR TITLE
Fix(maybe): route refresh broken for ember-engines

### DIFF
--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -17,6 +17,7 @@ interface IModel {
 export interface Route {
   inaccessibleByURL?: boolean;
   routeName: string;
+  fullRouteName?: string;
   context: unknown;
   events?: Dict<Function>;
   model?(

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -57,8 +57,9 @@ export default class NamedTransitionIntent<T extends Route> extends TransitionIn
 
     // Pivot handlers are provided for refresh transitions
     if (this.pivotHandler) {
+      let pivotHandlerName = this.pivotHandler.fullRouteName || this.pivotHandler.routeName;
       for (i = 0, len = parsedHandlers.length; i < len; ++i) {
-        if (parsedHandlers[i].handler === this.pivotHandler.routeName) {
+        if (parsedHandlers[i].handler === pivotHandlerName) {
           invalidateIndex = i;
           break;
         }


### PR DESCRIPTION
This is an odd one, so apologies in advance for the length... and double apologies for those who already know how Engines work since I'm probably choir-preaching a lot here. :P

### Short version
the `refresh()` hook (along with `refreshModel: true` query params) is currently broken in `ember-engines` (https://github.com/ember-engines/ember-engines/issues/614) when using Ember 3.6 and up, and I traced the issue to `router_js`... sorta. This patch fixes the issue, but I'm not sure if it's the best approach and I wanted to get some more eyes on it.

### Longer version
Routes in routable engines have two names -- `routeName`, which is relative to the root of the engine, and `fullRouteName`, an Engines-specific new property that contains the full route name relative to the application root. For instance, in my real-world app I have an engine named `analytics` mounted at the `home.tenant` route, like so:

```js
  // app/router.js
  // ...
  this.route('home', { path: '/' }, function() {
    this.route('tenant', { path: '/:tenant' }, function() {
       this.mount('analytics', { as: 'analytics', path: '/analytics' });
    });
  });
  // ...
```

Within this engine, I have a route named `interact`. This route's `routeName` is "interact", while its `fullRouteName` is "home.tenant.analytics.interact".

#### The trouble
During a `refresh()`, router.js is comparing the name of the route `refresh()` was called from against all currently-active routes in an attempt to refresh only what's necessary (presuming I'm reading the code flow right). Either way, the troublesome part is [here](https://github.com/tildeio/router.js/blob/f385d1162ab3307c166bf5b6b19eef45345dd8d0/lib/router/transition-intent/named-transition-intent.ts#L61):

```js
    // ...
    // Pivot handlers are provided for refresh transitions
    if (this.pivotHandler) {
      for (i = 0, len = parsedHandlers.length; i < len; ++i) {
        if (parsedHandlers[i].handler === this.pivotHandler.routeName) {
          invalidateIndex = i;
          break;
        }
      }
    }
    // ...
```

For engine routes, `parsedHandlers[i].handler` resolves to the _full name_ of the route -- e.g. "home.tenant.analytics.interact":

![pivothandler-welp1](https://user-images.githubusercontent.com/4601589/51929359-a70dc780-23bd-11e9-847e-d6b33a0374fe.png)

...and it's comparing it to the short name, `routeName`, e.g. "interact":

![pivothandler-welp2](https://user-images.githubusercontent.com/4601589/51929446-dde3dd80-23bd-11e9-8f14-152d94748a7b.png)

Since there's no match, no routes are refreshed. :(

In addition to breaking `refresh()`, this also has the unfortunate side effect of causing an infinite loop when trying to set a query param with `refreshModel: true`, since it tries to call `refresh()` behind the scenes (repeatedly, forever, probably by accident).

#### The fix... sorta
This patch is a bit of a sledgehammer quick-fix: it compares against `fullRouteName` if it exists, otherwise it falls back to `routeName`:
```js
    // ...
    // Pivot handlers are provided for refresh transitions
    if (this.pivotHandler) {
      let pivotHandlerName = this.pivotHandler.fullRouteName || this.pivotHandler.routeName;
      for (i = 0, len = parsedHandlers.length; i < len; ++i) {
        if (parsedHandlers[i].handler === pivotHandlerName) {
          invalidateIndex = i;
          break;
        }
      }
    }
    // ...
```

I added `fullRouteName` as a nullable property to Route's type definition so Typescript is happy, and all tests pass OK (though I haven't added a new one yet -- lemme know if I ought to).

'Course, that brings us to the matter of...

### Is this really router.js's responsibility?
I'm not sure.

This is definitely a case of adding specific functionality to a general-purpose library, but I've noodled a few other solutions and haven't come up with anything that works yet. There's a few spots where `ember-engines` makes extensions to Ember's core routing infrastructure (i.e. adding the `fullRouteName` property in the first place), but it doesn't touch the router microlib and I don't really see a good way to override this piece purely on engines' side... but I'm also not an Ember core dev so there's plenty of things I don't see. :P

On the flipside, there's precedent for adding engine-awareness features & fixes to `ember-cli` and whatnot, so maybe that makes sense here too? Either way, I'm not the one to make the call.

At any rate, if this isn't the way to go, do y'all have any ideas on how best to proceed with this? It's a bit of a pickle (and an upgrade blocker for my own app, heh), so every little bit is appreciated.

Whew. Crazy-long post for a 3-line change. Go me. :P
