### PR TITLE
[BUGFIX] Incorrect logging of messages with sequence numbers (tildeio/router.js#281)

### DIFF
--- a/lib/router/utils.ts
+++ b/lib/router/utils.ts
@@ -71,7 +71,7 @@ export function log(router: Router<any>, ...args: (string | number)[]): void {
     return;
   }
 
-  if (arguments.length === 2) {
+  if (args.length === 2) {
     let [sequence, msg] = args;
     router.log('Transition #' + sequence + ': ' + msg);
   } else {


### PR DESCRIPTION
The wrong "arg[ument]s" variable is being checked for length, which results in logging calls to log always being logged wrong. (#281)

Current:

`log(router, "foo")` => `Transition #: foo` (arguments.length === 2, args.length === 1)
`log(router, 1, "foo)` => `1` (arguments.length === 3, args.length === 2)

Expected:

`log(router, "foo")` => `foo`
`log(router, 1, "foo)` => `Transition #1: foo`