### PR TITLE
Fix `refresh` in Engines

### DIFF
--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -17,6 +17,7 @@ interface IModel {
 export interface Route {
   inaccessibleByURL?: boolean;
   routeName: string;
+  _internalName: string;
   context: unknown;
   events?: Dict<Function>;
   model?(
@@ -321,6 +322,7 @@ export default class InternalRouteInfo<T extends Route> {
   }
 
   private updateRoute(route: T) {
+    route._internalName = this.name;
     return (this.route = route);
   }
 

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -58,7 +58,7 @@ export default class NamedTransitionIntent<T extends Route> extends TransitionIn
     // Pivot handlers are provided for refresh transitions
     if (this.pivotHandler) {
       for (i = 0, len = parsedHandlers.length; i < len; ++i) {
-        if (parsedHandlers[i].handler === this.pivotHandler.routeName) {
+        if (parsedHandlers[i].handler === this.pivotHandler._internalName) {
           invalidateIndex = i;
           break;
         }

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -129,7 +129,7 @@ export {
 
 export function createHandler(name: string, options?: Dict<unknown>): Route {
   return Object.assign(
-    { name, routeName: name, context: undefined, names: [], handler: name },
+    { name, routeName: name, context: undefined, names: [], handler: name, _internalName: name },
     options
   );
 }


### PR DESCRIPTION
This is simply bringing back this functionality:

https://github.com/tildeio/router.js/blob/v2.0.0-beta.4/lib/router/handler-info.js#L66-L67

And

https://github.com/tildeio/router.js/blob/v2.0.0-beta.4/lib/router/transition-intent/named-transition-intent.js#L58