### PR TITLE
Fix crashing with Babel polyfill / Chrome <= v37.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 6
+  - 8
 
 sudo: false
 dist: trusty

--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -162,7 +162,7 @@ function createRouteInfoWithAttributes(
     },
   };
 
-  if (Object.isFrozen(routeInfo) || routeInfo.hasOwnProperty('attributes')) {
+  if (!Object.isExtensible(routeInfo) || routeInfo.hasOwnProperty('attributes')) {
     return Object.freeze(Object.assign({}, routeInfo, attributes));
   }
 
@@ -184,7 +184,7 @@ function attachMetadata(route: Route, routeInfo: RouteInfo) {
     },
   };
 
-  if (Object.isFrozen(routeInfo) || routeInfo.hasOwnProperty('metadata')) {
+  if (!Object.isExtensible(routeInfo) || routeInfo.hasOwnProperty('metadata')) {
     return Object.freeze(Object.assign({}, routeInfo, metadata));
   }
 


### PR DESCRIPTION
Closes: https://github.com/tildeio/router.js/issues/291

It seems with Babel polyfill included `Object.isFrozen` vs `Object.isExtensible` has different meaning:

<img width="841" alt="chrome-37-original-failure" src="https://user-images.githubusercontent.com/659945/72669867-af806780-3a3f-11ea-81d1-a35a4a5b32c5.png">

This change was tested on:

* IE 10
* Chrome v27+
* Chrome latest
* IE 9 (has some other non related failure)

See screenshots below:

**IE 9:**
<img width="504" alt="ie9" src="https://user-images.githubusercontent.com/659945/72669712-fcfbd500-3a3d-11ea-9cb3-ef2267da99ad.png">

**IE 10:**
<img width="450" alt="ie10" src="https://user-images.githubusercontent.com/659945/72669714-fec59880-3a3d-11ea-8636-d0bb64e37053.png">

**Chrome v27**
<img width="789" alt="chrome-27" src="https://user-images.githubusercontent.com/659945/72669715-008f5c00-3a3e-11ea-9f56-fd0b464b6564.png">

