### PR TITLE
Update queryParamsTransition to not change QueryParams if transition has been aborted

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -137,10 +137,12 @@ export default abstract class Router<T extends Route> {
 
       newTransition.promise = newTransition.promise!.then(
         (result: TransitionState<T> | Route | Error | undefined) => {
-          this._updateURL(newTransition, oldState);
-          this.didTransition(this.currentRouteInfos!);
-          this.toInfos(newTransition, newState.routeInfos, true);
-          this.routeDidChange(newTransition);
+          if (!newTransition.isAborted) {
+            this._updateURL(newTransition, oldState);
+            this.didTransition(this.currentRouteInfos!);
+            this.toInfos(newTransition, newState.routeInfos, true);
+            this.routeDidChange(newTransition);
+          }
           return result;
         },
         null,


### PR DESCRIPTION
https://github.com/emberjs/ember.js/issues/18568 