### PR TITLE
Add Failing Tests for QP-replacement during Transition

### DIFF
--- a/tests/query_params_test.ts
+++ b/tests/query_params_test.ts
@@ -4,6 +4,7 @@ import { Dict, Maybe } from 'router/core';
 import RouteInfo from 'router/route-info';
 import { Promise } from 'rsvp';
 import {
+  consumeAllFinalQueryParams,
   createHandler,
   flushBackburner,
   module,
@@ -76,15 +77,6 @@ scenarios.forEach(function (scenario) {
     }
     router = new QPRouter();
     router.map(fn);
-  }
-
-  function consumeAllFinalQueryParams(params: Dict<unknown>, finalParams: Dict<unknown>[]) {
-    for (let key in params) {
-      let value = params[key];
-      delete params[key];
-      finalParams.push({ key: key, value: value });
-    }
-    return true;
   }
 
   test('a change in query params fires a queryParamsDidChange event', function (assert) {

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -11,6 +11,7 @@ import { TransitionError } from 'router/transition-state';
 import { Promise, reject } from 'rsvp';
 import {
   assertAbort,
+  consumeAllFinalQueryParams,
   createHandler,
   flushBackburner,
   handleURL,
@@ -6223,6 +6224,97 @@ scenarios.forEach(function (scenario) {
 
     assert.equal(fooModelCount, 1, 'Foo model should be called once');
     assert.equal(barModelCount, 1, 'Bar model should be called once');
+  });
+
+  test('Calling transitionTo with the `replace` method during initial transition with only query params changes should use updateURL', function (assert) {
+    map(assert, function (match) {
+      match('/first').to('first');
+    });
+
+    routes.first = createHandler('first', {
+      model(params: Dict<unknown>) {
+        // Pass query params through to `afterModel` hook
+        return params.queryParams;
+      },
+      afterModel(model: Dict<unknown>) {
+        // Ensure we only redirect the first time through here
+        if (!model.foo) {
+          router
+            .transitionTo('first', {
+              queryParams: {
+                foo: 'bar',
+              },
+            })
+            .method('replace');
+        }
+      },
+
+      events: {
+        // Ensure query params are considered in transition
+        finalizeQueryParamChange: consumeAllFinalQueryParams,
+      },
+    });
+
+    router.updateURL = (url) => {
+      assert.step(`Updated the URL to ${url}`);
+    };
+
+    router.replaceURL = (url) => {
+      assert.step(`Replaced the URL with ${url}`);
+    };
+
+    transitionTo(router, 'first');
+    flushBackburner();
+
+    assert.verifySteps(['Updated the URL to /first?foo=bar']);
+  });
+
+  test('Calling transitionTo with the `replace` method after initial transition with only query params changes should use updateURL', function (assert) {
+    map(assert, function (match) {
+      match('/first').to('first');
+      match('/second').to('second');
+    });
+
+    routes.first = createHandler('first');
+    routes.second = createHandler('second', {
+      model(params: Dict<unknown>) {
+        // Pass query params through to `afterModel` hook
+        return params.queryParams;
+      },
+      afterModel(model: Dict<unknown>) {
+        // Ensure we only redirect the first time through here
+        if (!model.foo) {
+          router
+            .transitionTo('second', {
+              queryParams: {
+                foo: 'bar',
+              },
+            })
+            .method('replace');
+        }
+      },
+
+      events: {
+        // Ensure query params are considered in transition
+        finalizeQueryParamChange: consumeAllFinalQueryParams,
+      },
+    });
+
+    router.updateURL = (url) => {
+      assert.step(`Updated the URL to ${url}`);
+    };
+
+    router.replaceURL = (url) => {
+      assert.step(`Replaced the URL with ${url}`);
+    };
+
+    transitionTo(router, 'first');
+    flushBackburner();
+
+    transitionTo(router, 'second');
+    flushBackburner();
+
+    assert.verifySteps(['Updated the URL to /first', 'Updated the URL to /second?foo=bar']);
   });
 
   test('transitioning to the same route with different context should not reenter the route', function (assert) {

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -229,3 +229,12 @@ export function trigger(
     throw new Error("Nothing handled the event '" + name + "'.");
   }
 }
+
+export function consumeAllFinalQueryParams(params: Dict<unknown>, finalParams: Dict<unknown>[]) {
+  for (let key in params) {
+    let value = params[key];
+    delete params[key];
+    finalParams.push({ key: key, value: value });
+  }
+  return true;
+}


### PR DESCRIPTION
As part of investigating what parts of the failing tests in https://github.com/emberjs/ember.js/pull/19092 might be part of `router.js` -- as a means of getting to a solution for https://github.com/emberjs/ember.js/issues/18416 -- I wrote up these tests to try to isolate the behavior that _should_ be happening here.

Essentially, it seems to me that if you perform a new "replacement" transition during an active "update" transition which _only_ changes the query params, the browser should only push one item into the History stack; a URL update to the URL _with_ the query params.

However, that's not what _actually_ happens; in reality, a `replaceURL` happens from the "replacement" transition and _then_ the `updateURL` happens. This gets the browser's **Back** button all kinds of confused.
