### PR TITLE
Add better Transition debugging information.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "start": "ember server",
     "test": "ember test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@glimmer/env": "^0.1.7"
+  },
   "devDependencies": {
     "@babel/plugin-transform-modules-amd": "^7.10.5",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
@@ -39,6 +41,7 @@
     "@types/qunit": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
+    "babel-plugin-debug-macros": "^0.3.3",
     "backburner.js": "^2.6.0",
     "broccoli-babel-transpiler": "^7.6.0",
     "broccoli-concat": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,6 +216,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
 "@iarna/toml@2.2.5":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
@@ -902,6 +907,13 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+babel-plugin-debug-macros@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz#29c3449d663f61c7385f5b8c72d8015b069a5cb7"
+  integrity sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==
+  dependencies:
+    semver "^5.3.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -6310,7 +6322,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
Expose a few nice debugging tools when working with a transition:

```ts
interface Transition {
  /**
    In non-production builds, this function will return the stack that this Transition was
    created within. In production builds, this function will not be present.

    @method debugCreationStack
    @return string
  */
  debugCreationStack?: () => string | undefined;

  /**
    In non-production builds, this function will return the stack that this Transition was
    aborted within (or `undefined` if the Transition has not been aborted yet). In production
    builds, this function will not be present.

    @method debugAbortStack
    @return string
  */
  debugAbortStack?: () => string | undefined;

  /**
    In non-production builds, this property references the Transition that _this_ Transition
    was derived from or `undefined` if this transition did not derive from another. In
    production builds, this property will not be present.

    @property debugPreviousTransition
    @type {Transition | undefined}
  */
  debugPreviousTransition: Maybe<Transition<T>>;
}
```

---

Note: I've confirmed that Ember's build pipeline properly replaces the
`if (DEBUG) {` bits with `true` and `false` as appropriate:

  ```js
  if (true
      /* DEBUG */
  ) {
    var _error = new Error(`Transition creation stack`);

    this.debugCreationStack = () => _error.stack;

    this.debugPreviousTransition = previousTransition;
  }
```