### PR TITLE
Simplify TransitionState resolution system.

### DIFF
--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -40,7 +40,7 @@ export interface Route {
   buildRouteInfoMetadata?(): unknown;
 }
 
-export type Continuation = () => PromiseLike<boolean> | boolean;
+export type Continuation = () => boolean;
 
 export interface RouteInfo {
   readonly name: string;
@@ -376,11 +376,9 @@ export default class InternalRouteInfo<T extends Route> {
   }
 
   private checkForAbort<T>(shouldContinue: Continuation, value: T) {
-    return Promise.resolve(shouldContinue()).then(function () {
-      // We don't care about shouldContinue's resolve value;
-      // pass along the original value passed to this fn.
-      return value;
-    }, null);
+    shouldContinue();
+
+    return value;
   }
 
   private stashResolvedModel(transition: InternalTransition<T>, resolvedModel: Dict<unknown>) {

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -169,11 +169,11 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
       }
 
       this.sequence = router.currentSequence++;
-      this.promise = state
-        .resolve(() => !this.isAborted, this)
-        .catch((result: TransitionError) => {
-          return Promise.reject(this.router.transitionDidError(result, this));
-        }, promiseLabel('Handle Abort'));
+      this.promise = state.resolve(this).catch((result: TransitionError) => {
+        let error = this.router.transitionDidError(result, this);
+
+        throw error;
+      }, promiseLabel('Handle Abort'));
     } else {
       this.promise = Promise.resolve(this[STATE_SYMBOL]!);
       this[PARAMS_SYMBOL] = {};

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -170,13 +170,7 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
 
       this.sequence = router.currentSequence++;
       this.promise = state
-        .resolve(() => {
-          if (this.isAborted) {
-            return Promise.reject(false, promiseLabel('Transition aborted - reject'));
-          }
-
-          return Promise.resolve(true);
-        }, this)
+        .resolve(() => !this.isAborted, this)
         .catch((result: TransitionError) => {
           return Promise.reject(this.router.transitionDidError(result, this));
         }, promiseLabel('Handle Abort'));

--- a/tests/route_info_test.ts
+++ b/tests/route_info_test.ts
@@ -1,6 +1,6 @@
 import { Transition } from 'router';
 import { Dict } from 'router/core';
-import RouteInfo, {
+import {
   ResolvedRouteInfo,
   Route,
   toReadOnlyRouteInfo,

--- a/tests/route_info_test.ts
+++ b/tests/route_info_test.ts
@@ -9,12 +9,8 @@ import RouteInfo, {
 } from 'router/route-info';
 import InternalTransition from 'router/transition';
 import URLTransitionIntent from 'router/transition-intent/url-transition-intent';
-import { reject, resolve } from 'rsvp';
+import { resolve } from 'rsvp';
 import { createHandler, createHandlerInfo, module, test, TestRouter } from './test_helpers';
-
-function noop() {
-  return resolve(true);
-}
 
 module('RouteInfo');
 
@@ -43,9 +39,10 @@ test('RouteInfo can be aborted mid-resolve', function (assert) {
 
   let routeInfo = createHandlerInfo('stub');
 
-  function abortResolve() {
+  function abortResolve(): boolean {
     assert.ok(true, 'abort was called');
-    return reject('LOL');
+
+    throw new Error('foo');
   }
 
   routeInfo.resolve(abortResolve, {} as Transition).catch(function (error: Error) {
@@ -81,7 +78,7 @@ test('RouteInfo#resolve runs beforeModel hook on handler', function (assert) {
     }),
   });
 
-  routeInfo.resolve(noop, transition as Transition);
+  routeInfo.resolve(() => true, transition as Transition);
 });
 
 test('RouteInfo#resolve runs getModel hook', function (assert) {
@@ -95,7 +92,7 @@ test('RouteInfo#resolve runs getModel hook', function (assert) {
     },
   });
 
-  routeInfo.resolve(noop, transition as Transition);
+  routeInfo.resolve(() => true, transition as Transition);
 });
 
 test('RouteInfo#resolve runs afterModel hook on handler', function (assert) {
@@ -118,7 +115,7 @@ test('RouteInfo#resolve runs afterModel hook on handler', function (assert) {
   });
 
   routeInfo
-    .resolve(noop, transition as Transition)
+    .resolve(() => true, transition as Transition)
     .then(function (resolvedRouteInfo: RouteInfo<Route>) {
       assert.equal(resolvedRouteInfo.context, model, 'RouteInfo resolved with correct model');
     });
@@ -146,7 +143,7 @@ test('UnresolvedRouteInfoByParam gets its model hook called', function (assert) 
     })
   );
 
-  routeInfo.resolve(noop, transition as Transition);
+  routeInfo.resolve(() => true, transition as Transition);
 });
 
 test('UnresolvedRouteInfoByObject does NOT get its model hook called', function (assert) {
@@ -173,10 +170,12 @@ test('UnresolvedRouteInfoByObject does NOT get its model hook called', function 
     resolve({ name: 'dorkletons' })
   );
 
-  routeInfo.resolve(noop, {} as Transition).then(function (resolvedRouteInfo: RouteInfo<Route>) {
-    // @ts-ignore
-    assert.equal(resolvedRouteInfo.context!.name, 'dorkletons');
-  });
+  routeInfo
+    .resolve(() => true, {} as Transition)
+    .then(function (resolvedRouteInfo: RouteInfo<Route>) {
+      // @ts-ignore
+      assert.equal(resolvedRouteInfo.context!.name, 'dorkletons');
+    });
 });
 
 test('RouteInfo.find', function (assert) {

--- a/tests/transition_state_test.ts
+++ b/tests/transition_state_test.ts
@@ -7,7 +7,7 @@ import {
   UnresolvedRouteInfoByParam,
 } from 'router/route-info';
 import TransitionState, { TransitionError } from 'router/transition-state';
-import { Promise, reject, resolve } from 'rsvp';
+import { Promise, resolve } from 'rsvp';
 import {
   createHandler,
   createHandlerInfo,
@@ -54,7 +54,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function (assert) {
 
   function keepGoing() {
     assert.ok(true, 'continuation function was called');
-    return Promise.resolve(false);
+    return true;
   }
 
   state.resolve(keepGoing, {} as Transition).then(function (result: TransitionState<Route>) {
@@ -63,7 +63,7 @@ test("#resolve delegates to handleInfo objects' resolve()", function (assert) {
 });
 
 test('State resolution can be halted', function (assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   let state = new TransitionState();
 
@@ -81,11 +81,10 @@ test('State resolution can be halted', function (assert) {
   ];
 
   function keepGoing() {
-    return reject('NOPE');
+    return false;
   }
 
   state.resolve(keepGoing, {} as Transition).catch(function (reason: TransitionError) {
-    assert.equal(reason.error, 'NOPE');
     assert.ok(reason.wasAborted, 'state resolution was correctly marked as aborted');
   });
 
@@ -118,12 +117,8 @@ test('Integration w/ HandlerInfos', function (assert) {
     new UnresolvedRouteInfoByObject(router, 'bar', ['bar_id'], resolve(barModel)),
   ];
 
-  function noop() {
-    return Promise.resolve(false);
-  }
-
   state
-    .resolve(noop, transition as Transition)
+    .resolve(() => true, transition as Transition)
     .then(function (result: TransitionState<Route>) {
       let models = [];
       for (let i = 0; i < result.routeInfos.length; i++) {


### PR DESCRIPTION
* Reduce extraneous promise creation
* Remove `Continuation` system (use `transition.isAborted` directly)