### PR TITLE
fix: qp-only transition during initial transition

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -120,7 +120,7 @@ export default abstract class Router<T extends Route> {
       // perform a URL update at the end. This gives
       // the user the ability to set the url update
       // method (default is replaceState).
-      let newTransition = new InternalTransition(this, undefined, undefined);
+      let newTransition = new InternalTransition(this, undefined, newState);
       newTransition.queryParamsOnly = true;
 
       oldState.queryParams = this.finalizeQueryParamChange(


### PR DESCRIPTION
Seems to fix https://github.com/emberjs/ember.js/issues/18577.

![image](https://user-images.githubusercontent.com/834636/97607601-7be05e00-1a11-11eb-9c25-7b6d4fd832a9.png)
