### PR TITLE
[BUGFIX beta] provide transition to setupContext for internal transit…

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -229,9 +229,9 @@ export default abstract class Router<T extends Route> {
     }
 
     if (isIntermediate) {
-      let transition = new InternalTransition(this, undefined, undefined);
+      let transition = new InternalTransition(this, undefined, newState);
       this.toReadOnlyInfos(transition, newState);
-      this.setupContexts(newState);
+      this.setupContexts(newState, transition);
 
       this.routeWillChange(transition);
       return this.activeTransition!;

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -5379,7 +5379,7 @@ scenarios.forEach(function (scenario) {
   });
 
   test('intermediateTransitionTo() has the correct RouteInfo objects', function (assert) {
-    assert.expect(5);
+    assert.expect(6);
     routes = {
       application: createHandler('application'),
       foo: createHandler('foo', {
@@ -5400,6 +5400,8 @@ scenarios.forEach(function (scenario) {
         enteredCount++;
       } else if (enteredCount === 1) {
         assert.equal(transition.to!.name, 'loading', 'entering');
+        // https://github.com/emberjs/ember.js/issues/14438
+        assert.equal(transition[STATE_SYMBOL].routeInfos.length, 2, 'with routeInfos present');
         enteredCount++;
       } else {
         assert.equal(transition.to!.name, 'foo', 'back to');


### PR DESCRIPTION
…ions

Prior https://github.com/tildeio/router.js/commit/e792f2c76a5ef03c9a3e548b309cee364dd0138f we were calling `this.setupContext(newState, transition)` for intermediate transitions, which got replaced with `this.setupContexts(newState)`. This results in buggy behavior when query params get lost in certain scenarios.

Refs: https://github.com/emberjs/ember.js/issues/14438

Closes https://github.com/emberjs/ember.js/issues/14438 (hopefully)