### PR TITLE
Refactor TransitionAbort to builder interface

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -14,7 +14,7 @@ import InternalTransition, {
   QUERY_PARAMS_SYMBOL,
   STATE_SYMBOL,
 } from './transition';
-import TransitionAbortedError from './transition-aborted-error';
+import { throwIfAborted, isTransitionAborted } from './transition-aborted-error';
 import { TransitionIntent } from './transition-intent';
 import NamedTransitionIntent from './transition-intent/named-transition-intent';
 import URLTransitionIntent from './transition-intent/url-transition-intent';
@@ -371,7 +371,7 @@ export default abstract class Router<T extends Route> {
       // Resolve with the final route.
       return routeInfos[routeInfos.length - 1].route!;
     } catch (e) {
-      if (!(e instanceof TransitionAbortedError)) {
+      if (!isTransitionAborted(e)) {
         let infos = transition[STATE_SYMBOL]!.routeInfos;
         transition.trigger(true, 'error', e, transition, infos[infos.length - 1].route);
         transition.abort();
@@ -523,9 +523,7 @@ export default abstract class Router<T extends Route> {
         }
       }
 
-      if (transition && transition.isAborted) {
-        throw new TransitionAbortedError();
-      }
+      throwIfAborted(transition);
 
       route.context = context;
 
@@ -537,9 +535,7 @@ export default abstract class Router<T extends Route> {
         route.setup(context!, transition!);
       }
 
-      if (transition && transition.isAborted) {
-        throw new TransitionAbortedError();
-      }
+      throwIfAborted(transition);
 
       currentRouteInfos.push(routeInfo);
       return route;

--- a/lib/router/transition-state.ts
+++ b/lib/router/transition-state.ts
@@ -3,6 +3,7 @@ import { Dict } from './core';
 import InternalRouteInfo, { Route, ResolvedRouteInfo } from './route-info';
 import Transition from './transition';
 import { forEach, promiseLabel } from './utils';
+import { throwIfAborted } from './transition-aborted-error';
 
 interface IParams {
   [key: string]: unknown;
@@ -72,9 +73,7 @@ function proceed<T extends Route>(
 
   // Proceed after ensuring that the redirect hook
   // didn't abort this transition by transitioning elsewhere.
-  if (transition.isAborted) {
-    throw new Error('Transition aborted');
-  }
+  throwIfAborted(transition);
 
   return resolveOneRouteInfo(currentState, transition);
 }

--- a/lib/router/transition.ts
+++ b/lib/router/transition.ts
@@ -2,7 +2,7 @@ import { Promise } from 'rsvp';
 import { Dict, Maybe, Option } from './core';
 import InternalRouteInfo, { Route, RouteInfo, RouteInfoWithAttributes } from './route-info';
 import Router from './router';
-import TransitionAborted, { ITransitionAbortedError } from './transition-aborted-error';
+import { TransitionAbortedError, buildTransitionAborted } from './transition-aborted-error';
 import { OpaqueIntent } from './transition-intent';
 import TransitionState, { TransitionError } from './transition-state';
 import { log, promiseLabel } from './utils';
@@ -439,9 +439,10 @@ export default class Transition<T extends Route> implements Partial<Promise<T>> 
 
   Logs and returns an instance of TransitionAborted.
  */
-export function logAbort(transition: Transition<any>): ITransitionAbortedError {
+export function logAbort(transition: Transition<any>): TransitionAbortedError {
   log(transition.router, transition.sequence, 'detected abort.');
-  return new TransitionAborted();
+
+  return buildTransitionAborted();
 }
 
 export function isTransition(obj: unknown): obj is typeof Transition {

--- a/tests/test_helpers.ts
+++ b/tests/test_helpers.ts
@@ -3,10 +3,10 @@ import Router, { Route, Transition } from 'router';
 import { Dict } from 'router/core';
 import RouteInfo, { UnresolvedRouteInfoByParam } from 'router/route-info';
 import { logAbort, PublicTransition } from 'router/transition';
-import TransitionAbortedError from 'router/transition-aborted-error';
 import { TransitionError } from 'router/transition-state';
 import { UnrecognizedURLError } from 'router/unrecognized-url-error';
 import { configure, resolve } from 'rsvp';
+import { isTransitionAborted } from 'router/transition-aborted-error';
 
 QUnit.config.testTimeout = 1000;
 
@@ -45,7 +45,7 @@ function module(name: string, options?: any) {
 
 function assertAbort(assert: Assert) {
   return function _assertAbort(e: Error) {
-    assert.ok(e instanceof TransitionAbortedError, 'transition was redirected/aborted');
+    assert.ok(isTransitionAborted(e), 'transition was redirected/aborted');
   };
 }
 

--- a/tests/transition-aborted-error_test.ts
+++ b/tests/transition-aborted-error_test.ts
@@ -1,4 +1,8 @@
-import TransitionAbortedError from 'router/transition-aborted-error';
+import {
+  throwIfAborted,
+  isTransitionAborted,
+  buildTransitionAborted,
+} from 'router/transition-aborted-error';
 import { module, test } from './test_helpers';
 
 module('transition-aborted-error');
@@ -7,7 +11,7 @@ test('correct inheritance and name', function (assert) {
   let error;
 
   try {
-    throw new TransitionAbortedError('Message');
+    throw buildTransitionAborted();
   } catch (e) {
     error = e;
   }
@@ -19,6 +23,17 @@ test('correct inheritance and name', function (assert) {
     "TransitionAbortedError has the name 'TransitionAborted'"
   );
 
-  assert.ok(error instanceof TransitionAbortedError);
+  assert.ok(isTransitionAborted(error));
   assert.ok(error instanceof Error);
+});
+
+test('throwIfAborted', function (assert) {
+  throwIfAborted(undefined);
+  throwIfAborted(null);
+  throwIfAborted({});
+  throwIfAborted({ apple: false });
+  throwIfAborted({ isAborted: false });
+  throwIfAborted({ isAborted: false, other: 'key' });
+  assert.throws(() => throwIfAborted({ isAborted: true }), /TransitionAborted/);
+  assert.throws(() => throwIfAborted({ isAborted: true, other: 'key' }), /TransitionAborted/);
 });


### PR DESCRIPTION
Migrate `TransitionAbortedError` to builder + interface.

TODO:

- [x] Rebase to include the changes in #306
