### PR TITLE
Ensure query params are preserved through an intermediate loading state transition

### DIFF
--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -140,7 +140,7 @@ export default class NamedTransitionIntent<T extends Route> extends TransitionIn
     }
 
     merge(newState.queryParams, this.queryParams || {});
-    if (isIntermediate) {
+    if (isIntermediate && oldState.queryParams) {
       merge(newState.queryParams, oldState.queryParams);
     }
 

--- a/lib/router/transition-intent/named-transition-intent.ts
+++ b/lib/router/transition-intent/named-transition-intent.ts
@@ -140,6 +140,9 @@ export default class NamedTransitionIntent<T extends Route> extends TransitionIn
     }
 
     merge(newState.queryParams, this.queryParams || {});
+    if (isIntermediate) {
+      merge(newState.queryParams, oldState.queryParams);
+    }
 
     return newState;
   }

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -5376,7 +5376,7 @@ scenarios.forEach(function (scenario) {
   });
 
   test('intermediateTransitionTo() has the correct RouteInfo objects', function (assert) {
-    assert.expect(6);
+    assert.expect(9);
     routes = {
       application: createHandler('application'),
       foo: createHandler('foo', {
@@ -5394,28 +5394,23 @@ scenarios.forEach(function (scenario) {
     router.routeWillChange = (transition: Transition) => {
       if (enteredCount === 0) {
         assert.equal(transition.to!.name, 'foo', 'going to');
-        enteredCount++;
+        assert.equal(transition.to!.queryParams.qux, '42', 'going to with query params');
       } else if (enteredCount === 1) {
         assert.equal(transition.to!.name, 'loading', 'entering');
+        assert.equal(transition.to!.queryParams.qux, '42', 'intermediate also has query params');
         // https://github.com/emberjs/ember.js/issues/14438
         assert.equal(transition[STATE_SYMBOL].routeInfos.length, 2, 'with routeInfos present');
-        enteredCount++;
-      } else {
-        assert.equal(transition.to!.name, 'foo', 'back to');
-        enteredCount++;
       }
+      enteredCount++;
       assert.equal(transition.from, null);
     };
 
     router.routeDidChange = (transition: Transition) => {
-      if (enteredCount === 1) {
-        assert.equal(transition.to!.name, 'loading');
-      } else {
-        assert.equal(transition.to!.name, 'foo', 'landed at');
-      }
+      assert.equal(transition.to!.name, 'foo', 'landed at');
+      assert.equal(enteredCount, 2);
     };
 
-    transitionTo(router, '/foo');
+    transitionTo(router, '/foo?qux=42');
   });
 
   test("intermediateTransitionTo() forces an immediate intermediate transition that doesn't cancel currently active async transitions", function (assert) {


### PR DESCRIPTION
related to https://github.com/emberjs/ember.js/pull/19448

Previously, the assertion on line 5400 would have failed 