### PR TITLE
README: change getHandler to getRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ myHandlers.newPost = {
   }
 };
 
-router.getHandler = function(name) {
+router.getRoute = function(name) {
   return myHandlers[name];
 };
 ```


### PR DESCRIPTION
This PR changes getHandler method in README to getRoute.