### PR TITLE
Fix followRedirects when source is async and destination is sync

### DIFF
--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -4682,6 +4682,35 @@ scenarios.forEach(function (scenario) {
       });
   });
 
+  test('Transition#followRedirects() works correctly when redirecting from an async model hook', function (assert) {
+    assert.expect(2);
+
+    routes.index = createHandler('index', {
+      beforeModel: function () {
+        return Promise.resolve(true).then(() => {
+          return router.transitionTo('about');
+        });
+      },
+    });
+
+    routes.about = createHandler('about', {
+      setup: function () {
+        assert.ok(true, 'about#setup was called');
+      },
+    });
+
+    router
+      .transitionTo('/index')
+      .followRedirects()
+      .then(function (handler: Route) {
+        assert.equal(
+          handler,
+          routes.about,
+          'followRedirects works with redirect from async hook transitions'
+        );
+      });
+  });
+
   test("Returning a redirecting Transition from a model hook doesn't cause things to explode", function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
The previous implementation of `followRedirects()` would catch a transition rejection and check the router for an `activeTransition`. This can become problematic in async situations because the destination transition may have resolved before the `reject` is scheduled on the previous transition. One such case is when redirecting from an async model hook to a destination route with synchronous model hooks.

This commit updates the `followRedirects()` logic to explicitly follow the redirect chain rather than relying on the presence of an `activeTransition`. This makes following redirects work correctly regardless of any scheduling concerns.

This problem has been noted in the context of the `visit()` test helper:

- https://github.com/emberjs/ember-test-helpers/issues/332
- https://github.com/emberjs/ember.js/issues/17150