### PR TITLE
Calling recognize should not affect the transition.from query params for subsequent transitions

### DIFF
--- a/lib/router/router.ts
+++ b/lib/router/router.ts
@@ -171,7 +171,10 @@ export default abstract class Router<R extends Route> {
       return newState;
     }
 
-    let readonlyInfos = toReadOnlyRouteInfo(newState.routeInfos, newState.queryParams);
+    let readonlyInfos = toReadOnlyRouteInfo(newState.routeInfos, newState.queryParams, {
+      includeAttributes: false,
+      localizeMapUpdates: true,
+    });
     return readonlyInfos[readonlyInfos.length - 1] as RouteInfo;
   }
 
@@ -188,7 +191,10 @@ export default abstract class Router<R extends Route> {
       let routeInfosWithAttributes = toReadOnlyRouteInfo(
         newState!.routeInfos,
         newTransition[QUERY_PARAMS_SYMBOL],
-        true
+        {
+          includeAttributes: true,
+          localizeMapUpdates: false,
+        }
       ) as RouteInfoWithAttributes[];
       return routeInfosWithAttributes[routeInfosWithAttributes.length - 1];
     });
@@ -773,11 +779,10 @@ export default abstract class Router<R extends Route> {
 
   private fromInfos(newTransition: OpaqueTransition, oldRouteInfos: InternalRouteInfo<R>[]) {
     if (newTransition !== undefined && oldRouteInfos.length > 0) {
-      let fromInfos = toReadOnlyRouteInfo(
-        oldRouteInfos,
-        Object.assign({}, this._lastQueryParams),
-        true
-      ) as RouteInfoWithAttributes[];
+      let fromInfos = toReadOnlyRouteInfo(oldRouteInfos, Object.assign({}, this._lastQueryParams), {
+        includeAttributes: true,
+        localizeMapUpdates: false,
+      }) as RouteInfoWithAttributes[];
       newTransition!.from = fromInfos[fromInfos.length - 1] || null;
     }
   }
@@ -791,7 +796,7 @@ export default abstract class Router<R extends Route> {
       let toInfos = toReadOnlyRouteInfo(
         newRouteInfos,
         Object.assign({}, newTransition[QUERY_PARAMS_SYMBOL]),
-        includeAttributes
+        { includeAttributes, localizeMapUpdates: false }
       );
       newTransition!.to = toInfos[toInfos.length - 1] || null;
     }

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -1380,7 +1380,7 @@ scenarios.forEach(function (scenario) {
       })
       .then(() => {
         secondParam = true;
-        router.recognize('/search?term=foo');
+        router.recognize('/search?wat=foo');
         return router.transitionTo({ queryParams: { term: 'c' } });
       });
   });

--- a/tests/router_test.ts
+++ b/tests/router_test.ts
@@ -1324,6 +1324,67 @@ scenarios.forEach(function (scenario) {
     });
   });
 
+  test('calling recognize should not affect the transition.from query params for subsequent transitions', function (assert) {
+    assert.expect(12);
+    map(assert, function (match) {
+      match('/').to('index');
+      match('/search').to('search');
+    });
+
+    routes = {
+      search: createHandler('search'),
+    };
+
+    let firstParam = false;
+    let secondParam = false;
+
+    router.routeWillChange = (transition: Transition) => {
+      if (secondParam) {
+        assert.deepEqual(transition.to!.queryParams, { term: 'c' }, 'going to next page with qps');
+        assert.deepEqual(
+          isPresent(transition.from) && transition.from!.queryParams,
+          { term: 'b' },
+          'has previous qps'
+        );
+      } else if (firstParam) {
+        assert.deepEqual(transition.to!.queryParams, { term: 'b' }, 'going to page with qps');
+        assert.deepEqual(
+          isPresent(transition.from) && transition.from!.queryParams,
+          {},
+          'from never has qps'
+        );
+      } else {
+        assert.equal(transition.from, null);
+        assert.deepEqual(transition.to!.queryParams, {});
+      }
+    };
+
+    router.routeDidChange = (transition: Transition) => {
+      if (secondParam) {
+        assert.deepEqual(transition.to!.queryParams, { term: 'c' });
+        assert.deepEqual(isPresent(transition.from) && transition.from!.queryParams, { term: 'b' });
+      } else if (firstParam) {
+        assert.deepEqual(transition.to!.queryParams, { term: 'b' });
+        assert.deepEqual(isPresent(transition.from) && transition.from!.queryParams, {});
+      } else {
+        assert.equal(transition.from, null);
+        assert.deepEqual(transition.to!.queryParams, {});
+      }
+    };
+
+    router
+      .transitionTo('/')
+      .then(() => {
+        firstParam = true;
+        return router.transitionTo('search', { queryParams: { term: 'b' } });
+      })
+      .then(() => {
+        secondParam = true;
+        router.recognize('/search?term=foo');
+        return router.transitionTo({ queryParams: { term: 'c' } });
+      });
+  });
+
   test('redirects route events', function (assert) {
     assert.expect(19);
     map(assert, function (match) {


### PR DESCRIPTION
**Problem Statement**
Calling router.recognize with a URL which matches the current route affects the transition.from.queryParams for subsequent transitions. I've created a [failing test here](https://github.com/tildeio/router.js/pull/336/files#diff-aff3d7c97cdfdd7d115fdcb826ff38eba2f43ecc9133a84db6c0a2ad1720c483R1327).

**Root Cause**
The root cause appears to be caused by the fact that `toReadOnlyRouteInfo` ([source](https://github.com/tildeio/router.js/blob/9320c7b1c1e887e73afd3700cd0093b9f34c9e6b/lib/router/route-info.ts#L63)) closes over a WeakMap for `ROUTE_INFOS` which is then mutated on subsequent calls (including calls from router.recognize).

**Proposed Solution**
This PR adds a new argument to `toReadOnlyRouteInfo`, `localizeMapUpdates`, which allows the function to conditionally use a locally scoped map instead of the map from the parent scope. Interestingly, always using a locally scoped map in `toReadOnlyRouteInfo` causes a number of tests to fail.

`recognize` was then updated to enable the new option ([see here](https://github.com/tildeio/router.js/pull/336/files#diff-aa02fbdf6eed24646fb6672a138e4fbc84c9f9cc04ecf2a6733ceba097988c29R176)).

This proposal passes this project's test suite and a large production Ember app's test suite.