### PR TITLE
Fix a type error when `exactOptionalPropertyTypes` is enabled

### DIFF
--- a/lib/router/route-info.ts
+++ b/lib/router/route-info.ts
@@ -224,7 +224,7 @@ export default class InternalRouteInfo<R extends Route> {
   name: string;
   params: Dict<unknown> | undefined = {};
   queryParams?: Dict<unknown>;
-  context?: ModelFor<R> | PromiseLike<ModelFor<R>>;
+  context?: ModelFor<R> | PromiseLike<ModelFor<R>> | undefined;
   isResolved = false;
 
   constructor(router: Router<R>, name: string, paramNames: string[], route?: R) {


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/20500

cc @wagenet 